### PR TITLE
Add Local 2 Global Attribute Mapper plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Local 2 Global Attribute Mapper
+
+Plugin do WooCommerce desenvolvido pela Evolury LTDA para mapear atributos locais de produtos para atributos globais (`pa_*`).
+
+## Principais recursos
+
+- Descoberta automática de atributos locais no produto.
+- Mapeamento assistido para atributos globais existentes ou criação de novos atributos/termos.
+- Pré-visualização (dry-run) com identificação do que será criado/atualizado.
+- Conversão das variações com preservação de estoque/SKU/preço.
+- Criação de templates reutilizáveis para aplicar em produtos futuros.
+- Suporte a CLI (`wp local2global map`) e endpoint REST (`/local2global/v1/map`).
+
+## Instalação
+
+1. Copie a pasta do plugin para `wp-content/plugins/local2global-attribute-mapper`.
+2. Ative em **Plugins** > **Local 2 Global Attribute Mapper**.
+
+## Uso básico
+
+1. Abra um produto no painel do WooCommerce.
+2. Na aba **Atributos**, clique em **Mapear atributos locais → globais**.
+3. Siga o assistente para escolher o atributo global e realizar o mapeamento dos valores.
+4. Revise a pré-visualização e aplique.
+
+## Linha de comando
+
+```
+wp local2global map --product=123 --attr="Cor:pa_cor" --term="Azul:azul" --create-missing=1 --apply-variations=1
+```
+
+## Requisitos
+
+- WordPress 6.4+
+- WooCommerce 8.6+
+- PHP 8.1+
+

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,111 @@
+.local2global-button-wrap {
+    margin: 1em 0;
+}
+
+body.modal-open {
+    overflow: hidden;
+}
+
+.local2global-modal[hidden] {
+    display: none;
+}
+
+.local2global-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 100000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: inherit;
+}
+
+.local2global-modal__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.local2global-modal__content {
+    position: relative;
+    background: #fff;
+    border-radius: 6px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+    width: 900px;
+    max-width: 95vw;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.local2global-modal__header,
+.local2global-modal__footer {
+    padding: 16px 24px;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.local2global-modal__footer {
+    border-bottom: 0;
+    border-top: 1px solid #e0e0e0;
+    display: flex;
+    justify-content: space-between;
+}
+
+.local2global-modal__body {
+    padding: 24px;
+    overflow: auto;
+}
+
+.local2global-modal__close {
+    border: 0;
+    background: transparent;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+.local2global-step {
+    display: none;
+}
+
+.local2global-step.is-active {
+    display: block;
+}
+
+.local2global-attribute-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.local2global-attribute-table th,
+.local2global-attribute-table td {
+    padding: 8px;
+    border-bottom: 1px solid #e5e5e5;
+    text-align: left;
+}
+
+.local2global-summary {
+    background: #f8f9fa;
+    border: 1px solid #dfe2e6;
+    padding: 16px;
+    border-radius: 4px;
+}
+
+.local2global-log {
+    max-height: 200px;
+    overflow-y: auto;
+    background: #1d2327;
+    color: #fff;
+    font-family: monospace;
+    padding: 12px;
+    border-radius: 4px;
+}
+
+.local2global-tag {
+    display: inline-block;
+    padding: 2px 6px;
+    margin-inline-end: 4px;
+    border-radius: 3px;
+    background: #e0f2ff;
+    color: #1f6feb;
+    font-size: 12px;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,704 @@
+/* global Local2GlobalSettings */
+(function (wp, settings) {
+    if (!settings || !settings.productId) {
+        return;
+    }
+
+    const { __ } = wp.i18n;
+    const apiFetch = wp.apiFetch;
+
+    apiFetch.use(apiFetch.createNonceMiddleware(settings.rest.nonce));
+
+    const state = {
+        productId: settings.productId,
+        stepIndex: 0,
+        attributes: [],
+        mapping: [],
+        options: {
+            update_variations: true,
+            auto_create_terms: true,
+            create_backup: true,
+            save_template: true,
+        },
+        dryRun: null,
+        log: [],
+    };
+
+    const modal = document.getElementById('local2global-modal');
+    const modalBody = modal ? modal.querySelector('.local2global-modal__body') : null;
+    const modalTitle = modal ? modal.querySelector('#local2global-modal-title') : null;
+    const nextButton = modal ? modal.querySelector('.local2global-next') : null;
+    const prevButton = modal ? modal.querySelector('.local2global-prev') : null;
+
+    const steps = [
+        {
+            id: 'discover',
+            title: settings.i18n.discover,
+            render: renderDiscoverStep,
+        },
+        {
+            id: 'select-attribute',
+            title: __('Selecionar atributos globais', 'local2global'),
+            render: renderSelectAttributeStep,
+        },
+        {
+            id: 'term-matrix',
+            title: __('Matriz de mapeamento de termos', 'local2global'),
+            render: renderTermMatrixStep,
+        },
+        {
+            id: 'options',
+            title: __('Opções avançadas', 'local2global'),
+            render: renderOptionsStep,
+        },
+        {
+            id: 'dry-run',
+            title: settings.i18n.dryRunTitle,
+            render: renderDryRunStep,
+        },
+        {
+            id: 'apply',
+            title: settings.i18n.applyTitle,
+            render: renderApplyStep,
+        },
+    ];
+
+    function openModal() {
+        if (!modal) {
+            return;
+        }
+
+        state.stepIndex = 0;
+        state.log = [];
+        state.dryRun = null;
+
+        discoverAttributes().then(() => {
+            modal.removeAttribute('hidden');
+            document.body.classList.add('modal-open');
+            renderStep();
+            focusModal();
+        }).catch((error) => {
+            window.alert(error.message || error);
+        });
+    }
+
+    function closeModal() {
+        if (!modal) {
+            return;
+        }
+
+        modal.setAttribute('hidden', 'hidden');
+        document.body.classList.remove('modal-open');
+    }
+
+    function focusModal() {
+        window.requestAnimationFrame(() => {
+            modalBody && modalBody.focus();
+        });
+    }
+
+    function renderStep() {
+        if (!modalBody || !modalTitle) {
+            return;
+        }
+
+        const step = steps[state.stepIndex];
+        modalTitle.textContent = step.title;
+
+        modalBody.innerHTML = '';
+        step.render(modalBody);
+
+        prevButton.disabled = state.stepIndex === 0;
+        prevButton.textContent = __('Voltar', 'local2global');
+
+        if (state.stepIndex === steps.length - 1) {
+            nextButton.textContent = __('Fechar', 'local2global');
+        } else if (state.stepIndex === steps.length - 2) {
+            nextButton.textContent = settings.i18n.apply;
+        } else if (state.stepIndex === steps.length - 3) {
+            nextButton.textContent = settings.i18n.dryRun;
+        } else {
+            nextButton.textContent = __('Continuar', 'local2global');
+        }
+
+        nextButton.disabled = false;
+    }
+
+    function renderDiscoverStep(container) {
+        const info = document.createElement('div');
+        info.innerHTML = '<p>' + __('Abaixo estão os atributos locais detectados no produto.', 'local2global') + '</p>';
+        container.appendChild(info);
+
+        const table = document.createElement('table');
+        table.className = 'local2global-attribute-table';
+        table.innerHTML = '<thead><tr><th>' + __('Atributo local', 'local2global') + '</th><th>' + __('Valores', 'local2global') + '</th><th>' + __('Uso', 'local2global') + '</th></tr></thead>';
+        const tbody = document.createElement('tbody');
+
+        state.attributes.forEach((attr) => {
+            const tr = document.createElement('tr');
+            const badge = attr.in_variations ? '<span class="local2global-tag">' + __('Variações', 'local2global') + '</span>' : '';
+            tr.innerHTML = '<td>' + escapeHtml(attr.label) + '</td>' +
+                '<td>' + attr.values.map(escapeHtml).join(', ') + '</td>' +
+                '<td><span class="local2global-tag">' + __('Atributos', 'local2global') + '</span>' + badge + '</td>';
+            tbody.appendChild(tr);
+        });
+
+        table.appendChild(tbody);
+        container.appendChild(table);
+    }
+
+    function renderSelectAttributeStep(container) {
+        const intro = document.createElement('p');
+        intro.textContent = __('Selecione um atributo global correspondente para cada atributo local.', 'local2global');
+        container.appendChild(intro);
+
+        state.mapping.forEach((map, index) => {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'local2global-attribute-card';
+
+            const heading = document.createElement('h3');
+            heading.textContent = map.local_label;
+            wrapper.appendChild(heading);
+
+            const selectLabel = document.createElement('label');
+            selectLabel.textContent = __('Atributo global', 'local2global');
+            const select = document.createElement('select');
+            select.dataset.index = index;
+            select.innerHTML = '<option value="">' + __('— Selecionar —', 'local2global') + '</option>';
+            settings.attributes.forEach((attr) => {
+                const option = document.createElement('option');
+                option.value = attr.slug;
+                option.textContent = attr.label + ' (' + attr.slug + ')';
+                if (attr.slug === map.target_tax) {
+                    option.selected = true;
+                }
+                select.appendChild(option);
+            });
+
+            const createOption = document.createElement('option');
+            createOption.value = '__create_new__';
+            createOption.textContent = __('Criar novo atributo global', 'local2global');
+            select.appendChild(createOption);
+
+            select.addEventListener('change', (event) => {
+                const target = event.target;
+                const entry = state.mapping[parseInt(target.dataset.index, 10)];
+                if (target.value === '__create_new__') {
+                    entry.create_attribute = true;
+                    entry.target_tax = 'pa_' + slugify(entry.local_label);
+                    select.value = '';
+                } else {
+                    entry.target_tax = target.value;
+                    entry.create_attribute = false;
+                }
+                renderStep();
+            });
+
+            selectLabel.appendChild(select);
+            wrapper.appendChild(selectLabel);
+
+            const labelField = document.createElement('label');
+            labelField.textContent = __('Rótulo do atributo global', 'local2global');
+            const labelInput = document.createElement('input');
+            labelInput.type = 'text';
+            labelInput.value = map.target_label || map.local_label;
+            labelInput.dataset.index = index;
+            labelInput.addEventListener('input', (event) => {
+                state.mapping[parseInt(event.target.dataset.index, 10)].target_label = event.target.value;
+            });
+            labelField.appendChild(labelInput);
+            wrapper.appendChild(labelField);
+
+            const slugField = document.createElement('label');
+            slugField.textContent = __('Slug alvo (pa_slug)', 'local2global');
+            const slugInput = document.createElement('input');
+            slugInput.type = 'text';
+            slugInput.value = map.target_tax;
+            slugInput.dataset.index = index;
+            slugInput.addEventListener('input', (event) => {
+                state.mapping[parseInt(event.target.dataset.index, 10)].target_tax = ensurePaPrefix(event.target.value);
+            });
+            slugField.appendChild(slugInput);
+            wrapper.appendChild(slugField);
+
+            const createCheckbox = document.createElement('label');
+            const createInput = document.createElement('input');
+            createInput.type = 'checkbox';
+            createInput.checked = !!map.create_attribute;
+            createInput.dataset.index = index;
+            createInput.addEventListener('change', (event) => {
+                state.mapping[parseInt(event.target.dataset.index, 10)].create_attribute = event.target.checked;
+            });
+            createCheckbox.appendChild(createInput);
+            createCheckbox.appendChild(document.createTextNode(' ' + __('Criar atributo se necessário', 'local2global')));
+            wrapper.appendChild(createCheckbox);
+
+            if (state.attributes[index].suggestion) {
+                const suggestion = document.createElement('p');
+                suggestion.className = 'description';
+                suggestion.textContent = __('Template sugerido aplicado. Revise antes de continuar.', 'local2global');
+                wrapper.appendChild(suggestion);
+            }
+
+            container.appendChild(wrapper);
+        });
+    }
+
+    function renderTermMatrixStep(container) {
+        const intro = document.createElement('div');
+        intro.innerHTML = '<p>' + __('Associe cada valor local a um termo global existente ou indique a criação automática.', 'local2global') + '</p>';
+        const autoMap = document.createElement('button');
+        autoMap.type = 'button';
+        autoMap.className = 'button';
+        autoMap.textContent = settings.i18n.autoMap;
+        autoMap.addEventListener('click', () => {
+            Promise.all(state.mapping.map(loadTermOptions)).then(() => {
+                state.mapping.forEach(autoMapAttributeTerms);
+                renderStep();
+            });
+        });
+        intro.appendChild(autoMap);
+        container.appendChild(intro);
+
+        state.mapping.forEach((map, mapIndex) => {
+            const block = document.createElement('section');
+            block.innerHTML = '<h3>' + escapeHtml(map.local_label) + '</h3>';
+
+            const table = document.createElement('table');
+            table.className = 'local2global-attribute-table';
+            table.innerHTML = '<thead><tr><th>' + __('Valor local', 'local2global') + '</th><th>' + __('Termo global', 'local2global') + '</th></tr></thead>';
+            const tbody = document.createElement('tbody');
+
+            map.terms.forEach((term, termIndex) => {
+                const tr = document.createElement('tr');
+                const localValueCell = document.createElement('td');
+                localValueCell.textContent = term.local_value;
+                tr.appendChild(localValueCell);
+
+                const globalCell = document.createElement('td');
+
+                const select = document.createElement('select');
+                select.className = 'local2global-term-select';
+                select.dataset.attrIndex = mapIndex;
+                select.dataset.termIndex = termIndex;
+                select.innerHTML = '<option value="">' + __('— Selecionar termo existente —', 'local2global') + '</option>';
+
+                ensureTermOptions(map).forEach((termOption) => {
+                    const option = document.createElement('option');
+                    option.value = termOption.slug;
+                    option.textContent = termOption.name + ' (' + termOption.slug + ')';
+                    if (termOption.slug === term.term_slug) {
+                        option.selected = true;
+                    }
+                    select.appendChild(option);
+                });
+
+                select.addEventListener('change', (event) => {
+                    const attrIdx = parseInt(event.target.dataset.attrIndex, 10);
+                    const termIdx = parseInt(event.target.dataset.termIndex, 10);
+                    const entry = state.mapping[attrIdx].terms[termIdx];
+                    entry.term_slug = event.target.value;
+                    entry.term_name = event.target.options[event.target.selectedIndex]?.textContent?.split(' (')[0] || entry.term_name;
+                    entry.create = false;
+                });
+
+                const customWrapper = document.createElement('div');
+                customWrapper.className = 'local2global-term-custom';
+
+                const nameInput = document.createElement('input');
+                nameInput.type = 'text';
+                nameInput.placeholder = __('Nome do termo', 'local2global');
+                nameInput.value = term.term_name || term.local_value;
+                nameInput.dataset.attrIndex = mapIndex;
+                nameInput.dataset.termIndex = termIndex;
+                nameInput.addEventListener('input', onTermNameChange);
+
+                const slugInput = document.createElement('input');
+                slugInput.type = 'text';
+                slugInput.placeholder = __('Slug', 'local2global');
+                slugInput.value = term.term_slug || slugify(term.term_name || term.local_value);
+                slugInput.dataset.attrIndex = mapIndex;
+                slugInput.dataset.termIndex = termIndex;
+                slugInput.addEventListener('input', onTermSlugChange);
+
+                const createLabel = document.createElement('label');
+                const createCheckbox = document.createElement('input');
+                createCheckbox.type = 'checkbox';
+                createCheckbox.checked = !!term.create;
+                createCheckbox.dataset.attrIndex = mapIndex;
+                createCheckbox.dataset.termIndex = termIndex;
+                createCheckbox.addEventListener('change', (event) => {
+                    const attrIdx = parseInt(event.target.dataset.attrIndex, 10);
+                    const termIdx = parseInt(event.target.dataset.termIndex, 10);
+                    state.mapping[attrIdx].terms[termIdx].create = event.target.checked;
+                });
+                createLabel.appendChild(createCheckbox);
+                createLabel.appendChild(document.createTextNode(' ' + settings.i18n.createTerm));
+
+                const refreshButton = document.createElement('button');
+                refreshButton.type = 'button';
+                refreshButton.className = 'button button-small';
+                refreshButton.textContent = __('Atualizar termos', 'local2global');
+                refreshButton.addEventListener('click', () => {
+                    loadTermOptions(map).then(() => renderStep());
+                });
+
+                customWrapper.appendChild(select);
+                customWrapper.appendChild(nameInput);
+                customWrapper.appendChild(slugInput);
+                customWrapper.appendChild(createLabel);
+                customWrapper.appendChild(refreshButton);
+
+                globalCell.appendChild(customWrapper);
+                tr.appendChild(globalCell);
+                tbody.appendChild(tr);
+            });
+
+            table.appendChild(tbody);
+            block.appendChild(table);
+            container.appendChild(block);
+        });
+    }
+
+    function renderOptionsStep(container) {
+        const description = document.createElement('p');
+        description.textContent = __('Ajuste as opções antes de aplicar o mapeamento.', 'local2global');
+        container.appendChild(description);
+
+        const options = [
+            { key: 'update_variations', label: settings.i18n.updateVariations },
+            { key: 'auto_create_terms', label: settings.i18n.createTerm },
+            { key: 'create_backup', label: settings.i18n.backup },
+            { key: 'save_template', label: __('Aplicar como template para outros produtos', 'local2global') },
+        ];
+
+        options.forEach((option) => {
+            const label = document.createElement('label');
+            const input = document.createElement('input');
+            input.type = 'checkbox';
+            input.checked = !!state.options[option.key];
+            input.dataset.optionKey = option.key;
+            input.addEventListener('change', (event) => {
+                state.options[event.target.dataset.optionKey] = event.target.checked;
+            });
+            label.appendChild(input);
+            label.appendChild(document.createTextNode(' ' + option.label));
+            container.appendChild(label);
+        });
+    }
+
+    function renderDryRunStep(container) {
+        if (!state.dryRun) {
+            container.innerHTML = '<p>' + __('Calculando pré-visualização…', 'local2global') + '</p>';
+            return;
+        }
+
+        if (state.dryRun.errors.length) {
+            const errors = document.createElement('div');
+            errors.className = 'notice notice-error';
+            errors.innerHTML = '<p><strong>' + __('Problemas encontrados:', 'local2global') + '</strong></p><ul>' +
+                state.dryRun.errors.map((err) => '<li>' + escapeHtml(err) + '</li>').join('') + '</ul>';
+            container.appendChild(errors);
+        }
+
+        state.dryRun.attributes.forEach((attr) => {
+            const section = document.createElement('section');
+            section.innerHTML = '<h3>' + escapeHtml(attr.local_label) + '</h3>';
+            const summary = document.createElement('div');
+            summary.className = 'local2global-summary';
+            summary.innerHTML = '<p>' + __('Taxonomia alvo:', 'local2global') + ' <strong>' + escapeHtml(attr.target_tax) + '</strong></p>' +
+                '<p>' + __('Termos existentes:', 'local2global') + ' ' + attr.terms.existing.length + '</p>' +
+                '<p>' + __('Termos a criar:', 'local2global') + ' ' + attr.terms.create.length + '</p>';
+            section.appendChild(summary);
+            container.appendChild(section);
+        });
+    }
+
+    function renderApplyStep(container) {
+        const summary = document.createElement('div');
+        summary.innerHTML = '<p>' + __('Acompanhe o progresso. Os logs são atualizados automaticamente.', 'local2global') + '</p>';
+        container.appendChild(summary);
+
+        const logContainer = document.createElement('pre');
+        logContainer.className = 'local2global-log';
+        logContainer.textContent = state.log.join('\n');
+        container.appendChild(logContainer);
+    }
+
+    function discoverAttributes() {
+        return apiFetch({
+            path: '/local2global/v1/discover?product_id=' + state.productId,
+        }).then((data) => {
+            state.attributes = data.attributes || [];
+            state.mapping = state.attributes.map((attr) => buildMappingFromAttribute(attr));
+        });
+    }
+
+    function buildMappingFromAttribute(attr) {
+        const suggestion = attr.suggestion || {};
+        const mapping = {
+            local_attr: attr.name,
+            local_label: attr.label,
+            target_tax: ensurePaPrefix(suggestion.target_tax || ''),
+            target_label: suggestion.target_label || attr.label,
+            create_attribute: !suggestion.target_tax,
+            terms: attr.values.map((value) => ({
+                local_value: value,
+                term_slug: suggestion.terms ? suggestion.terms[value] : '',
+                term_name: value,
+                create: !!suggestion.terms && !suggestion.terms[value],
+            })),
+            termOptions: [],
+        };
+
+        mapping.terms.forEach((term) => {
+            if (!term.term_slug) {
+                term.term_slug = slugify(term.term_name || term.local_value);
+            }
+            if (!suggestion.terms) {
+                term.create = state.options.auto_create_terms;
+            }
+        });
+
+        return mapping;
+    }
+
+    function ensureTermOptions(map) {
+        if (!map.termOptions || !map.termOptions.length) {
+            loadTermOptions(map).then(() => {
+                if (steps[state.stepIndex]?.id === 'term-matrix') {
+                    renderStep();
+                }
+            });
+        }
+        return map.termOptions || [];
+    }
+
+    function loadTermOptions(map) {
+        if (!map.target_tax) {
+            return Promise.resolve([]);
+        }
+
+        return apiFetch({
+            path: '/local2global/v1/terms/' + map.target_tax,
+        }).then((response) => {
+            map.termOptions = response.terms || [];
+            return map.termOptions;
+        }).catch(() => {
+            map.termOptions = [];
+        });
+    }
+
+    function onTermNameChange(event) {
+        const attrIdx = parseInt(event.target.dataset.attrIndex, 10);
+        const termIdx = parseInt(event.target.dataset.termIndex, 10);
+        const entry = state.mapping[attrIdx].terms[termIdx];
+        entry.term_name = event.target.value;
+        if (!entry.term_slug || entry.term_slug === slugify(entry.local_value)) {
+            entry.term_slug = slugify(event.target.value);
+        }
+    }
+
+    function onTermSlugChange(event) {
+        const attrIdx = parseInt(event.target.dataset.attrIndex, 10);
+        const termIdx = parseInt(event.target.dataset.termIndex, 10);
+        state.mapping[attrIdx].terms[termIdx].term_slug = slugify(event.target.value);
+    }
+
+    function performDryRun() {
+        nextButton.disabled = true;
+        state.dryRun = null;
+        return apiFetch({
+            path: '/local2global/v1/map',
+            method: 'POST',
+            data: {
+                product_id: state.productId,
+                mapping: serializeMapping(),
+                options: state.options,
+                mode: 'dry-run',
+            },
+        }).then((result) => {
+            state.dryRun = result;
+        }).catch((error) => {
+            window.alert(error.message || error);
+        }).finally(() => {
+            nextButton.disabled = false;
+            renderStep();
+        });
+    }
+
+    function applyMapping() {
+        nextButton.disabled = true;
+        prevButton.disabled = true;
+        state.log.push(__('Iniciando aplicação...', 'local2global'));
+        renderStep();
+
+        apiFetch({
+            path: '/local2global/v1/map',
+            method: 'POST',
+            data: {
+                product_id: state.productId,
+                mapping: serializeMapping(),
+                options: state.options,
+                mode: 'apply',
+            },
+        }).then((result) => {
+            state.log.push(__('Mapeamento concluído.', 'local2global'));
+            state.log.push(JSON.stringify(result));
+        }).catch((error) => {
+            state.log.push(__('Erro: ', 'local2global') + (error.message || error));
+        }).finally(() => {
+            nextButton.disabled = false;
+            prevButton.disabled = true;
+            nextButton.textContent = __('Fechar', 'local2global');
+            renderStep();
+        });
+    }
+
+    function serializeMapping() {
+        return state.mapping.map((map) => ({
+            local_attr: map.local_attr,
+            local_label: map.local_label,
+            target_tax: ensurePaPrefix(map.target_tax),
+            target_label: map.target_label,
+            create_attribute: map.create_attribute,
+            save_template: state.options.save_template,
+            terms: map.terms.map((term) => ({
+                local_value: term.local_value,
+                term_slug: term.term_slug,
+                term_name: term.term_name,
+                create: term.create,
+            })),
+        }));
+    }
+
+    function ensurePaPrefix(value) {
+        if (!value) {
+            return '';
+        }
+        if (value.startsWith('pa_')) {
+            return 'pa_' + slugify(value.replace(/^pa_/, ''));
+        }
+        return 'pa_' + slugify(value);
+    }
+
+    function slugify(value) {
+        return (value || '')
+            .toString()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+            .replace(/-{2,}/g, '-');
+    }
+
+    function autoMapAttributeTerms(map) {
+        if (!map.termOptions || !map.termOptions.length) {
+            return;
+        }
+        map.terms.forEach((term) => {
+            const normalizedLocal = normalizeString(term.local_value);
+            let bestMatch = null;
+            let bestScore = 0;
+            map.termOptions.forEach((option) => {
+                const normalizedOption = normalizeString(option.name);
+                if (normalizedOption === normalizedLocal || option.slug === slugify(term.local_value)) {
+                    bestMatch = option;
+                    bestScore = 1;
+                    return;
+                }
+                const distance = similarity(normalizedLocal, normalizedOption);
+                if (distance > bestScore) {
+                    bestScore = distance;
+                    bestMatch = option;
+                }
+            });
+            if (bestMatch && bestScore > 0.5) {
+                term.term_slug = bestMatch.slug;
+                term.term_name = bestMatch.name;
+                term.create = false;
+            }
+        });
+    }
+
+    function normalizeString(value) {
+        return slugify(value).replace(/-/g, '');
+    }
+
+    function similarity(a, b) {
+        if (!a.length || !b.length) {
+            return 0;
+        }
+        const matrix = Array.from({ length: a.length + 1 }, () => new Array(b.length + 1).fill(0));
+        for (let i = 0; i <= a.length; i++) {
+            matrix[i][0] = i;
+        }
+        for (let j = 0; j <= b.length; j++) {
+            matrix[0][j] = j;
+        }
+        for (let i = 1; i <= a.length; i++) {
+            for (let j = 1; j <= b.length; j++) {
+                const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+                matrix[i][j] = Math.min(
+                    matrix[i - 1][j] + 1,
+                    matrix[i][j - 1] + 1,
+                    matrix[i - 1][j - 1] + cost
+                );
+            }
+        }
+        const distance = matrix[a.length][b.length];
+        return 1 - distance / Math.max(a.length, b.length);
+    }
+
+    function escapeHtml(value) {
+        return (value || '').toString().replace(/[&<>"']/g, (char) => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;',
+        })[char]);
+    }
+
+    document.querySelectorAll('.local2global-open').forEach((button) => {
+        button.addEventListener('click', openModal);
+    });
+
+    modal?.querySelectorAll('[data-local2global-close]').forEach((button) => {
+        button.addEventListener('click', closeModal);
+    });
+
+    prevButton?.addEventListener('click', () => {
+        if (state.stepIndex === 0) {
+            return;
+        }
+        state.stepIndex -= 1;
+        renderStep();
+    });
+
+    nextButton?.addEventListener('click', () => {
+        if (state.stepIndex === steps.length - 1) {
+            closeModal();
+            return;
+        }
+
+        if (state.stepIndex === steps.length - 3) {
+            state.stepIndex += 1;
+            state.dryRun = null;
+            renderStep();
+            performDryRun();
+            return;
+        }
+
+        if (state.stepIndex === steps.length - 2) {
+            applyMapping();
+            state.stepIndex += 1;
+            renderStep();
+            return;
+        }
+
+        state.stepIndex += 1;
+        renderStep();
+    });
+})(window.wp, window.Local2GlobalSettings);

--- a/local2global-attribute-mapper.php
+++ b/local2global-attribute-mapper.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Plugin Name: Local 2 Global Attribute Mapper
+ * Description: Facilita o mapeamento de atributos locais do WooCommerce para atributos globais com variações e templates reutilizáveis.
+ * Plugin URI: https://evolury.com.br
+ * Author: Tássio Câmara
+ * Author URI: https://evolury.com.br
+ * Version: 0.1.0
+ * Requires at least: 6.4
+ * Requires PHP: 8.1
+ * Text Domain: local2global
+ * Domain Path: /languages
+ * WC requires at least: 8.6
+ * WC tested up to: 8.7
+ */
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+const VERSION = '0.1.0';
+
+/**
+ * Autoloader simplificado baseado em PSR-4.
+ *
+ * @param string $class Nome da classe.
+ */
+function autoload( string $class ): void {
+    if ( ! str_starts_with( $class, __NAMESPACE__ . '\\' ) ) {
+        return;
+    }
+
+    $relative = substr( $class, strlen( __NAMESPACE__ ) + 1 );
+    $relative = str_replace( '\\', DIRECTORY_SEPARATOR, $relative );
+    $path     = plugin_dir_path( __FILE__ ) . 'src/' . $relative . '.php';
+
+    if ( file_exists( $path ) ) {
+        require_once $path;
+    }
+}
+
+spl_autoload_register( __NAMESPACE__ . '\\autoload' );
+
+register_activation_hook( __FILE__, static function (): void {
+    ( new Setup\Activator( plugin_basename( __FILE__ ) ) )->maybe_declare_hpos_compatibility();
+} );
+
+add_action( 'plugins_loaded', static function (): void {
+    if ( ! class_exists( '\\WooCommerce' ) ) {
+        return;
+    }
+
+    load_plugin_textdomain( 'local2global', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+
+    $plugin = new Plugin( plugin_dir_path( __FILE__ ), plugin_basename( __FILE__ ) );
+    $plugin->init();
+} );

--- a/src/Admin/UI.php
+++ b/src/Admin/UI.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global\Admin;
+
+class UI {
+    public function __construct( private string $plugin_url ) {}
+
+    public function hooks(): void {
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+        add_action( 'woocommerce_product_options_attributes', [ $this, 'render_button' ] );
+        add_action( 'admin_footer', [ $this, 'render_modal' ] );
+    }
+
+    public function enqueue_assets( string $hook ): void {
+        if ( ! $this->is_product_screen( $hook ) ) {
+            return;
+        }
+
+        wp_register_style(
+            'local2global-admin',
+            $this->plugin_url . 'assets/css/admin.css',
+            [],
+            \Evolury\Local2Global\VERSION
+        );
+
+        wp_register_script(
+            'local2global-admin',
+            $this->plugin_url . 'assets/js/admin.js',
+            [ 'wp-api-fetch', 'wp-i18n' ],
+            \Evolury\Local2Global\VERSION,
+            true
+        );
+
+        $global_attributes = [];
+        foreach ( wc_get_attribute_taxonomies() as $taxonomy ) {
+            $global_attributes[] = [
+                'slug'  => 'pa_' . $taxonomy->attribute_name,
+                'label' => $taxonomy->attribute_label,
+            ];
+        }
+
+        $screen    = get_current_screen();
+        $productId = 0;
+        if ( isset( $screen->post_type ) && 'product' === $screen->post_type && isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $productId = (int) $_GET['post']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        }
+
+        wp_localize_script(
+            'local2global-admin',
+            'Local2GlobalSettings',
+            [
+                'rest'       => [
+                    'root'  => esc_url_raw( rest_url( 'local2global/v1' ) ),
+                    'nonce' => wp_create_nonce( 'wp_rest' ),
+                ],
+                'i18n'       => [
+                    'title'            => __( 'Mapear atributos locais → globais', 'local2global' ),
+                    'discover'         => __( 'Descobrir atributos locais', 'local2global' ),
+                    'dryRun'           => __( 'Dry-run', 'local2global' ),
+                    'apply'            => __( 'Aplicar', 'local2global' ),
+                    'autoMap'          => __( 'Auto-mapear por similaridade', 'local2global' ),
+                    'createTerm'       => __( 'Criar termo automaticamente', 'local2global' ),
+                    'updateVariations' => __( 'Atualizar variações', 'local2global' ),
+                    'backup'           => __( 'Criar backup para reversão', 'local2global' ),
+                    'template'         => __( 'Salvar como template', 'local2global' ),
+                    'dryRunTitle'      => __( 'Pré-visualização', 'local2global' ),
+                    'applyTitle'       => __( 'Aplicando mapeamento…', 'local2global' ),
+                    'done'             => __( 'Mapeamento concluído', 'local2global' ),
+                ],
+                'productId'  => $productId,
+                'attributes' => $global_attributes,
+            ]
+        );
+
+        wp_enqueue_style( 'local2global-admin' );
+        wp_enqueue_script( 'local2global-admin' );
+    }
+
+    public function render_button(): void {
+        global $post;
+        if ( empty( $post->ID ) ) {
+            return;
+        }
+
+        echo '<div class="local2global-button-wrap"><button type="button" class="button local2global-open">' . esc_html__( 'Mapear atributos locais → globais', 'local2global' ) . '</button></div>';
+    }
+
+    public function render_modal(): void {
+        $screen = get_current_screen();
+        if ( ! $screen || 'product' !== $screen->post_type ) {
+            return;
+        }
+
+        ?>
+        <div id="local2global-modal" class="local2global-modal" role="dialog" aria-modal="true" aria-labelledby="local2global-modal-title" hidden>
+            <div class="local2global-modal__overlay" data-local2global-close></div>
+            <div class="local2global-modal__content" role="document">
+                <header class="local2global-modal__header">
+                    <h1 id="local2global-modal-title"></h1>
+                    <button type="button" class="local2global-modal__close" aria-label="<?php esc_attr_e( 'Fechar', 'local2global' ); ?>" data-local2global-close>&times;</button>
+                </header>
+                <main class="local2global-modal__body" tabindex="0"></main>
+                <footer class="local2global-modal__footer">
+                    <button type="button" class="button button-secondary local2global-prev" disabled><?php esc_html_e( 'Voltar', 'local2global' ); ?></button>
+                    <button type="button" class="button button-primary local2global-next"><?php esc_html_e( 'Continuar', 'local2global' ); ?></button>
+                </footer>
+            </div>
+        </div>
+        <?php
+    }
+
+    private function is_product_screen( string $hook ): bool {
+        return in_array( $hook, [ 'post.php', 'post-new.php' ], true ) && 'product' === get_post_type();
+    }
+}

--- a/src/Cli/CLI_Command.php
+++ b/src/Cli/CLI_Command.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global\Cli;
+
+use Evolury\Local2Global\Services\Mapping_Service;
+use WP_CLI_Command;
+use WP_Query;
+
+class CLI_Command extends WP_CLI_Command {
+    public function __construct( private Mapping_Service $mapping ) {}
+
+    /**
+     * Mapeia atributos locais para globais via linha de comando.
+     *
+     * ## OPTIONS
+     *
+     * [--product=<id|all>]
+     * : ID do produto. Use "all" para aplicar a todos os produtos.
+     *
+     * [--attr=<local:pa_slug>]
+     * : Par atributo local e taxonomia alvo. Pode ser repetido.
+     *
+     * [--term=<valor_local:slug_global>]
+     * : Par valor local e slug global. Pode ser repetido.
+     *
+     * [--create-missing=<0|1>]
+     * : Criar termos faltantes automaticamente.
+     *
+     * [--apply-variations=<0|1>]
+     * : Atualizar variações.
+     *
+     * [--dry-run=<0|1>]
+     * : Executa em modo de pré-visualização.
+     */
+    public function map( array $args, array $assoc_args ): void {
+        $product_option = $assoc_args['product'] ?? null;
+        if ( ! $product_option ) {
+            \WP_CLI::error( 'Informe o parâmetro --product.' );
+        }
+
+        $products = [];
+        if ( 'all' === $product_option ) {
+            $query = new WP_Query(
+                [
+                    'post_type'      => 'product',
+                    'posts_per_page' => -1,
+                    'fields'         => 'ids',
+                ]
+            );
+            $products = $query->posts;
+        } else {
+            $products = [ (int) $product_option ];
+        }
+
+        $attr_inputs = (array) ( $assoc_args['attr'] ?? [] );
+        if ( empty( $attr_inputs ) ) {
+            \WP_CLI::error( 'Informe ao menos um --attr local:pa_slug.' );
+        }
+
+        $term_inputs = (array) ( $assoc_args['term'] ?? [] );
+        $term_config = [];
+        foreach ( $term_inputs as $input ) {
+            [ $local_value, $slug ] = array_pad( explode( ':', (string) $input, 2 ), 2, '' );
+            if ( '' === $local_value || '' === $slug ) {
+                continue;
+            }
+
+            $term_config[] = [
+                'local_value' => $local_value,
+                'term_slug'   => $slug,
+                'term_name'   => $local_value,
+                'create'      => ! empty( $assoc_args['create-missing'] ),
+            ];
+        }
+
+        $mapping = [];
+        foreach ( $attr_inputs as $attr_pair ) {
+            [ $local_attr, $target_tax ] = array_pad( explode( ':', (string) $attr_pair, 2 ), 2, '' );
+            if ( '' === $local_attr || '' === $target_tax ) {
+                continue;
+            }
+
+            $mapping[] = [
+                'local_attr'       => $local_attr,
+                'local_label'      => $local_attr,
+                'target_tax'       => $target_tax,
+                'target_label'     => $local_attr,
+                'create_attribute' => false,
+                'terms'            => $term_config,
+            ];
+        }
+
+        if ( empty( $mapping ) ) {
+            \WP_CLI::error( 'Mapeamento inválido.' );
+        }
+
+        $options = [
+            'auto_create_terms' => ! empty( $assoc_args['create-missing'] ),
+            'update_variations' => ! empty( $assoc_args['apply-variations'] ),
+            'create_backup'     => empty( $assoc_args['dry-run'] ),
+        ];
+
+        foreach ( $products as $product_id ) {
+            try {
+                if ( ! empty( $assoc_args['dry-run'] ) ) {
+                    $result = $this->mapping->dry_run( (int) $product_id, $mapping, $options );
+                    \WP_CLI::log( sprintf( 'Dry-run para o produto %d: %s', $product_id, wp_json_encode( $result ) ) );
+                } else {
+                    $result = $this->mapping->apply( (int) $product_id, $mapping, $options );
+                    \WP_CLI::success( sprintf( 'Mapeamento aplicado ao produto %d: %s', $product_id, wp_json_encode( $result ) ) );
+                }
+            } catch ( \Throwable $error ) {
+                \WP_CLI::warning( sprintf( 'Erro ao processar o produto %d: %s', $product_id, $error->getMessage() ) );
+            }
+        }
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global;
+
+use Evolury\Local2Global\Admin\UI;
+use Evolury\Local2Global\Cli\CLI_Command;
+use Evolury\Local2Global\Rest\Rest_Controller;
+use Evolury\Local2Global\Services\Discovery_Service;
+use Evolury\Local2Global\Services\Mapping_Service;
+use Evolury\Local2Global\Services\Rollback_Service;
+use Evolury\Local2Global\Services\Templates_Service;
+use Evolury\Local2Global\Services\Term_Service;
+use Evolury\Local2Global\Services\Variation_Service;
+use Evolury\Local2Global\Utils\Logger;
+
+class Plugin {
+    private Logger $logger;
+    private Templates_Service $templates;
+    private Discovery_Service $discovery;
+    private Term_Service $terms;
+    private Variation_Service $variations;
+    private Rollback_Service $rollback;
+    private Mapping_Service $mapping;
+    private UI $admin_ui;
+    private Rest_Controller $rest;
+
+    public function __construct( private string $plugin_dir, private string $plugin_basename ) {}
+
+    public function init(): void {
+        $this->logger     = new Logger();
+        $this->templates  = new Templates_Service( $this->logger );
+        $this->discovery  = new Discovery_Service( $this->templates );
+        $this->terms      = new Term_Service( $this->logger );
+        $this->variations = new Variation_Service( $this->logger );
+        $this->rollback   = new Rollback_Service( $this->logger );
+        $this->mapping    = new Mapping_Service( $this->terms, $this->variations, $this->templates, $this->rollback, $this->logger );
+
+        $this->admin_ui = new UI( plugin_dir_url( $this->plugin_dir . 'local2global-attribute-mapper.php' ) );
+        $this->admin_ui->hooks();
+
+        $this->rest = new Rest_Controller( $this->discovery, $this->mapping );
+        add_action( 'rest_api_init', [ $this->rest, 'register_routes' ] );
+
+        if ( defined( 'WP_CLI' ) && WP_CLI ) {
+            \WP_CLI::add_command( 'local2global', new CLI_Command( $this->mapping ) );
+        }
+    }
+}

--- a/src/Rest/Rest_Controller.php
+++ b/src/Rest/Rest_Controller.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global\Rest;
+
+use Evolury\Local2Global\Services\Discovery_Service;
+use Evolury\Local2Global\Services\Mapping_Service;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+class Rest_Controller {
+    private string $namespace = 'local2global/v1';
+
+    public function __construct( private Discovery_Service $discovery, private Mapping_Service $mapping ) {}
+
+    public function register_routes(): void {
+        register_rest_route(
+            $this->namespace,
+            '/discover',
+            [
+                'methods'             => 'GET',
+                'callback'            => [ $this, 'discover' ],
+                'permission_callback' => [ $this, 'permissions_check' ],
+                'args'                => [
+                    'product_id' => [
+                        'type'              => 'integer',
+                        'required'          => true,
+                        'sanitize_callback' => 'absint',
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/map',
+            [
+                'methods'             => 'POST',
+                'callback'            => [ $this, 'map' ],
+                'permission_callback' => [ $this, 'permissions_check' ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/terms/(?P<taxonomy>[a-z0-9_\-]+)',
+            [
+                'methods'             => 'GET',
+                'callback'            => [ $this, 'terms' ],
+                'permission_callback' => [ $this, 'permissions_check' ],
+                'args'                => [
+                    'search' => [
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                    'number' => [
+                        'type'    => 'integer',
+                        'default' => 100,
+                    ],
+                ],
+            ]
+        );
+    }
+
+    public function discover( WP_REST_Request $request ): WP_REST_Response {
+        $product_id = (int) $request->get_param( 'product_id' );
+        $data       = $this->discovery->discover( $product_id );
+
+        return new WP_REST_Response( $data );
+    }
+
+    public function map( WP_REST_Request $request ) {
+        $product_id = (int) $request->get_param( 'product_id' );
+        $mapping    = (array) $request->get_param( 'mapping' );
+        $options    = (array) $request->get_param( 'options' );
+        $mode       = (string) $request->get_param( 'mode' );
+
+        if ( 'apply' === $mode ) {
+            $result = $this->mapping->apply( $product_id, $mapping, $options );
+        } else {
+            $result = $this->mapping->dry_run( $product_id, $mapping, $options );
+        }
+
+        return new WP_REST_Response( $result );
+    }
+
+    public function terms( WP_REST_Request $request ): WP_REST_Response {
+        $taxonomy = sanitize_key( (string) $request['taxonomy'] );
+        $search   = (string) $request->get_param( 'search' );
+        $number   = (int) $request->get_param( 'number' );
+
+        $terms = get_terms(
+            [
+                'taxonomy'   => $taxonomy,
+                'hide_empty' => false,
+                'search'     => $search,
+                'number'     => $number,
+                'orderby'    => 'name',
+                'order'      => 'ASC',
+            ]
+        );
+
+        if ( is_wp_error( $terms ) ) {
+            return new WP_REST_Response( [ 'error' => $terms->get_error_message() ], 400 );
+        }
+
+        $data = array_map(
+            static fn( $term ) => [
+                'term_id' => (int) $term->term_id,
+                'name'    => (string) $term->name,
+                'slug'    => (string) $term->slug,
+            ],
+            $terms
+        );
+
+        return new WP_REST_Response( [ 'terms' => $data ] );
+    }
+
+    public function permissions_check(): bool|WP_Error {
+        if ( current_user_can( 'manage_woocommerce' ) || current_user_can( 'edit_products' ) ) {
+            return true;
+        }
+
+        return new WP_Error( 'local2global_forbidden', __( 'Permissão insuficiente.', 'local2global' ), [ 'status' => 403 ] );
+    }
+}

--- a/src/Services/Discovery_Service.php
+++ b/src/Services/Discovery_Service.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global\Services;
+
+use WC_Product;
+use WC_Product_Attribute;
+use WC_Product_Variation;
+
+class Discovery_Service {
+    public function __construct( private Templates_Service $templates ) {}
+
+    /**
+     * @return array{
+     *   attributes: array<int, array{
+     *     name: string,
+     *     label: string,
+     *     values: array<int, string>,
+     *     in_variations: bool,
+     *     suggestion: ?array
+     *   }>
+     * }
+     */
+    public function discover( int $product_id ): array {
+        $product = wc_get_product( $product_id );
+
+        if ( ! $product instanceof WC_Product ) {
+            return [ 'attributes' => [] ];
+        }
+
+        $attributes = [];
+        foreach ( $product->get_attributes() as $attribute ) {
+            if ( ! $attribute instanceof WC_Product_Attribute ) {
+                continue;
+            }
+
+            if ( $attribute->is_taxonomy() ) {
+                continue;
+            }
+
+            $values = array_map( 'wc_clean', (array) $attribute->get_options() );
+            $name   = (string) $attribute->get_name();
+            $label  = (string) ( $attribute->get_data()['name'] ?? $name );
+
+            $attributes[] = [
+                'name'          => $name,
+                'label'         => $label,
+                'values'        => $values,
+                'in_variations' => $this->attribute_used_in_variations( $product, $name, $values ),
+                'suggestion'    => $this->templates->get_template_for_label( $label ),
+            ];
+        }
+
+        return [ 'attributes' => $attributes ];
+    }
+
+    private function attribute_used_in_variations( WC_Product $product, string $attr_name, array $values ): bool {
+        if ( ! $product->is_type( 'variable' ) ) {
+            return false;
+        }
+
+        $children = $product->get_children();
+        if ( empty( $children ) ) {
+            return false;
+        }
+
+        $meta_key = 'attribute_' . sanitize_title( $attr_name );
+
+        foreach ( $children as $variation_id ) {
+            $variation = wc_get_product( $variation_id );
+            if ( ! $variation instanceof WC_Product_Variation ) {
+                continue;
+            }
+
+            $value = (string) $variation->get_meta( $meta_key );
+            if ( '' !== $value ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Services/Mapping_Service.php
+++ b/src/Services/Mapping_Service.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global\Services;
+
+use Evolury\Local2Global\Utils\Logger;
+use RuntimeException;
+use WC_Product;
+use WC_Product_Attribute;
+
+class Mapping_Service {
+    public function __construct(
+        private Term_Service $terms,
+        private Variation_Service $variations,
+        private Templates_Service $templates,
+        private Rollback_Service $rollback,
+        private Logger $logger
+    ) {}
+
+    public function dry_run( int $product_id, array $mapping, array $options = [] ): array {
+        $product = wc_get_product( $product_id );
+        if ( ! $product instanceof WC_Product ) {
+            throw new RuntimeException( 'Produto inválido.' );
+        }
+
+        $report = [
+            'product_id' => $product_id,
+            'attributes' => [],
+            'errors'     => [],
+        ];
+
+        foreach ( $mapping as $attribute_mapping ) {
+            $target_tax    = $this->sanitize_taxonomy( $attribute_mapping['target_tax'] ?? '' );
+            $local_label   = (string) ( $attribute_mapping['local_label'] ?? $attribute_mapping['local_attr'] ?? '' );
+            $create_attr   = ! empty( $attribute_mapping['create_attribute'] );
+            $term_actions  = [ 'create' => [], 'existing' => [] ];
+            $term_errors   = [];
+
+            if ( empty( $target_tax ) ) {
+                $term_errors[] = __( 'Taxonomia alvo não informada.', 'local2global' );
+            }
+
+            if ( taxonomy_exists( $target_tax ) ) {
+                $attribute_exists = true;
+            } else {
+                $attribute_exists = false;
+                if ( ! $create_attr ) {
+                    $term_errors[] = sprintf( __( 'Atributo global %s não existe e criação automática não foi selecionada.', 'local2global' ), $target_tax );
+                }
+            }
+
+            foreach ( $attribute_mapping['terms'] ?? [] as $term_map ) {
+                $local_value = (string) ( $term_map['local_value'] ?? '' );
+                $slug        = sanitize_title( $term_map['term_slug'] ?? $term_map['term_name'] ?? $local_value );
+                $term        = $attribute_exists ? term_exists( $slug, $target_tax ) : null;
+
+                if ( $term ) {
+                    $term_actions['existing'][] = $local_value;
+                } elseif ( ! empty( $term_map['create'] ) || ! empty( $options['auto_create_terms'] ) || ! $attribute_exists ) {
+                    $term_actions['create'][] = [ 'value' => $local_value, 'slug' => $slug ];
+                } else {
+                    $term_errors[] = sprintf( __( 'Termo %1$s não encontrado na taxonomia %2$s.', 'local2global' ), $local_value, $target_tax );
+                }
+            }
+
+            $report['attributes'][] = [
+                'local_label'      => $local_label,
+                'target_tax'       => $target_tax,
+                'attribute_exists' => $attribute_exists,
+                'create_attribute' => $create_attr && ! $attribute_exists,
+                'terms'            => $term_actions,
+                'errors'           => $term_errors,
+            ];
+
+            $report['errors'] = array_merge( $report['errors'], $term_errors );
+        }
+
+        return $report;
+    }
+
+    public function apply( int $product_id, array $mapping, array $options = [] ): array {
+        $product = wc_get_product( $product_id );
+        if ( ! $product instanceof WC_Product ) {
+            throw new RuntimeException( 'Produto inválido.' );
+        }
+
+        $attributes_before = $product->get_attributes();
+
+        if ( ! empty( $options['create_backup'] ) ) {
+            $this->rollback->create_backup( $product, $attributes_before );
+        }
+
+        $results = [
+            'created_terms' => [],
+            'existing_terms'=> [],
+            'updated_attrs' => [],
+            'variations'    => [],
+        ];
+
+        foreach ( $mapping as $attribute_mapping ) {
+            $target_tax    = $this->sanitize_taxonomy( $attribute_mapping['target_tax'] ?? '' );
+            $local_name    = (string) ( $attribute_mapping['local_attr'] ?? '' );
+            $local_label   = (string) ( $attribute_mapping['local_label'] ?? $local_name );
+            $create_attr   = ! empty( $attribute_mapping['create_attribute'] );
+            $terms_config  = $attribute_mapping['terms'] ?? [];
+
+            if ( empty( $target_tax ) || empty( $local_name ) ) {
+                throw new RuntimeException( 'Mapeamento incompleto.' );
+            }
+
+            $attribute_info = $this->terms->ensure_global_attribute( $target_tax, $attribute_mapping['target_label'] ?? $local_label, $create_attr, $attribute_mapping['attribute_args'] ?? [] );
+            $term_results   = $this->terms->ensure_terms( $attribute_info['taxonomy'], $terms_config, ! empty( $options['auto_create_terms'] ) );
+
+            $term_ids   = array_values( array_unique( array_map( static fn( array $item ) => $item['term_id'], $term_results ) ) );
+            $slug_map   = [];
+            $created    = [];
+            $existing   = [];
+
+            foreach ( $term_results as $term_result ) {
+                $normalized            = $this->normalize_local_value( $term_result['local_value'] );
+                $slug_map[ $normalized ] = $term_result['slug'];
+                if ( $term_result['created'] ) {
+                    $created[] = $term_result['slug'];
+                } else {
+                    $existing[] = $term_result['slug'];
+                }
+            }
+
+            $updated = $this->replace_attribute( $product, $local_name, $attribute_info['taxonomy'], $attribute_info['attribute_id'], $term_ids );
+            if ( ! $updated ) {
+                throw new RuntimeException( sprintf( 'Não foi possível localizar o atributo local %s no produto.', $local_name ) );
+            }
+
+            wp_set_object_terms( $product_id, $term_ids, $attribute_info['taxonomy'], false );
+
+            if ( ! empty( $options['update_variations'] ) ) {
+                $variation_stats = $this->variations->update_variations( $product, $attribute_info['taxonomy'], $local_name, $slug_map );
+                $results['variations'][ $attribute_info['taxonomy'] ] = $variation_stats;
+            }
+
+            if ( ! empty( $attribute_mapping['save_template'] ) ) {
+                $this->templates->save_template( $local_label, [
+                    'target_tax' => $attribute_info['taxonomy'],
+                    'terms'      => array_combine(
+                        array_map( static fn( array $item ) => $item['local_value'], $term_results ),
+                        array_map( static fn( array $item ) => $item['slug'], $term_results )
+                    ),
+                ] );
+            }
+
+            $results['created_terms'][ $attribute_info['taxonomy'] ]  = $created;
+            $results['existing_terms'][ $attribute_info['taxonomy'] ] = $existing;
+            $results['updated_attrs'][]                               = $attribute_info['taxonomy'];
+        }
+
+        $product->save();
+
+        wc_delete_product_transients( $product_id );
+
+        $this->logger->info( 'Mapeamento aplicado.', [ 'product_id' => $product_id, 'result' => $results ] );
+
+        return $results;
+    }
+
+    private function replace_attribute( WC_Product $product, string $local_name, string $taxonomy, int $attribute_id, array $term_ids ): bool {
+        $attributes = $product->get_attributes();
+        $replaced   = false;
+
+        foreach ( $attributes as $index => $attribute ) {
+            if ( ! $attribute instanceof WC_Product_Attribute ) {
+                continue;
+            }
+
+            $attr_name = sanitize_title( $attribute->get_name() );
+            if ( $attr_name !== sanitize_title( $local_name ) ) {
+                continue;
+            }
+
+            $new_attribute = new WC_Product_Attribute();
+            $new_attribute->set_id( $attribute_id );
+            $new_attribute->set_name( $taxonomy );
+            $new_attribute->set_options( $term_ids );
+            $new_attribute->set_visible( $attribute->get_visible() );
+            $new_attribute->set_variation( $attribute->get_variation() );
+            $new_attribute->set_position( $attribute->get_position() );
+            $new_attribute->set_taxonomy( true );
+
+            $attributes[ $index ] = $new_attribute;
+            $replaced              = true;
+            break;
+        }
+
+        if ( $replaced ) {
+            $product->set_attributes( $attributes );
+        }
+
+        return $replaced;
+    }
+
+    private function normalize_local_value( string $value ): string {
+        return strtolower( trim( wc_clean( $value ) ) );
+    }
+
+    private function sanitize_taxonomy( string $taxonomy ): string {
+        $taxonomy = sanitize_key( $taxonomy );
+        if ( '' === $taxonomy ) {
+            return $taxonomy;
+        }
+
+        if ( ! str_starts_with( $taxonomy, 'pa_' ) ) {
+            $taxonomy = 'pa_' . $taxonomy;
+        }
+
+        return $taxonomy;
+    }
+}

--- a/src/Services/Rollback_Service.php
+++ b/src/Services/Rollback_Service.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global\Services;
+
+use Evolury\Local2Global\Utils\Logger;
+use WC_Product;
+use WC_Product_Attribute;
+use WC_Product_Variation;
+
+class Rollback_Service {
+    private const META_KEY = '_local2global_backups';
+
+    public function __construct( private Logger $logger ) {}
+
+    /**
+     * @param array<int, WC_Product_Attribute> $original_attributes
+     */
+    public function create_backup( WC_Product $product, array $original_attributes ): string {
+        $backup_id = wp_generate_uuid4();
+        $data      = [
+            'created_at' => time(),
+            'attributes' => array_map( static fn( WC_Product_Attribute $attribute ) => $attribute->get_data(), $original_attributes ),
+            'variations' => $this->export_variations( $product ),
+        ];
+
+        $backups             = get_post_meta( $product->get_id(), self::META_KEY, true );
+        $backups             = is_array( $backups ) ? $backups : [];
+        $backups[ $backup_id ] = $data;
+
+        update_post_meta( $product->get_id(), self::META_KEY, $backups );
+        $this->logger->info( 'Backup criado para o produto.', [ 'product_id' => $product->get_id(), 'backup_id' => $backup_id ] );
+
+        return $backup_id;
+    }
+
+    public function restore_backup( int $product_id, string $backup_id ): bool {
+        $backups = get_post_meta( $product_id, self::META_KEY, true );
+        if ( empty( $backups[ $backup_id ] ) ) {
+            return false;
+        }
+
+        $data    = $backups[ $backup_id ];
+        $product = wc_get_product( $product_id );
+        if ( ! $product instanceof WC_Product ) {
+            return false;
+        }
+
+        $restored_attributes = [];
+        foreach ( $data['attributes'] as $attribute_data ) {
+            $attribute = new WC_Product_Attribute();
+            $attribute->set_props( $attribute_data );
+            $restored_attributes[] = $attribute;
+        }
+
+        $product->set_attributes( $restored_attributes );
+        $product->save();
+
+        $this->restore_variations( $product, $data['variations'] );
+
+        unset( $backups[ $backup_id ] );
+        update_post_meta( $product_id, self::META_KEY, $backups );
+
+        $this->logger->info( 'Backup restaurado.', [ 'product_id' => $product_id, 'backup_id' => $backup_id ] );
+
+        return true;
+    }
+
+    private function export_variations( WC_Product $product ): array {
+        if ( ! $product->is_type( 'variable' ) ) {
+            return [];
+        }
+
+        $variations = [];
+        foreach ( $product->get_children() as $variation_id ) {
+            $variation = wc_get_product( $variation_id );
+            if ( ! $variation instanceof WC_Product_Variation ) {
+                continue;
+            }
+
+            $variations[ $variation_id ] = [
+                'attributes' => $variation->get_attributes(),
+            ];
+        }
+
+        return $variations;
+    }
+
+    private function restore_variations( WC_Product $product, array $variations ): void {
+        foreach ( $variations as $variation_id => $data ) {
+            $variation = wc_get_product( (int) $variation_id );
+            if ( ! $variation instanceof WC_Product_Variation ) {
+                continue;
+            }
+
+            $variation->set_attributes( $data['attributes'] ?? [] );
+            $variation->save();
+        }
+
+        if ( $product->is_type( 'variable' ) ) {
+            \WC_Product_Variable::sync( $product, true );
+        }
+    }
+}

--- a/src/Services/Templates_Service.php
+++ b/src/Services/Templates_Service.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global\Services;
+
+use Evolury\Local2Global\Utils\Logger;
+
+class Templates_Service {
+    private const OPTION_KEY = 'local2global_attribute_templates';
+
+    public function __construct( private Logger $logger ) {}
+
+    public function get_templates(): array {
+        $templates = get_option( self::OPTION_KEY, [] );
+
+        if ( ! is_array( $templates ) ) {
+            return [];
+        }
+
+        return $templates;
+    }
+
+    public function get_template_for_label( string $label ): ?array {
+        $templates = $this->get_templates();
+        $label_key = $this->normalise_label( $label );
+
+        foreach ( $templates as $stored_label => $config ) {
+            if ( $this->normalise_label( $stored_label ) === $label_key ) {
+                return $config;
+            }
+        }
+
+        return null;
+    }
+
+    public function save_template( string $label, array $config ): void {
+        $templates             = $this->get_templates();
+        $templates[ $label ]   = $config;
+        $updated               = update_option( self::OPTION_KEY, $templates, false );
+
+        if ( $updated ) {
+            $this->logger->info(
+                sprintf( 'Template atualizado para o atributo local "%s"', $label ),
+                [ 'template' => $config ]
+            );
+        }
+    }
+
+    private function normalise_label( string $label ): string {
+        return strtolower( trim( $label ) );
+    }
+}

--- a/src/Services/Term_Service.php
+++ b/src/Services/Term_Service.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global\Services;
+
+use Evolury\Local2Global\Utils\Logger;
+use RuntimeException;
+
+class Term_Service {
+    /** @var array<string, array<string, array{term_id:int, slug:string}>> */
+    private array $term_cache = [];
+
+    public function __construct( private Logger $logger ) {}
+
+    /**
+     * @return array{attribute_id:int, taxonomy:string}
+     */
+    public function ensure_global_attribute( string $target_taxonomy, string $label, bool $create_if_missing = false, array $args = [] ): array {
+        $target_taxonomy = sanitize_key( $target_taxonomy );
+        if ( ! str_starts_with( $target_taxonomy, 'pa_' ) ) {
+            $target_taxonomy = 'pa_' . $target_taxonomy;
+        }
+
+        $label          = sanitize_text_field( $label );
+
+        $attribute_slug = substr( $target_taxonomy, 3 );
+        $attribute_id   = wc_attribute_taxonomy_id_by_name( $attribute_slug );
+
+        if ( ! $attribute_id ) {
+            if ( ! $create_if_missing ) {
+                throw new RuntimeException( sprintf( 'Atributo global %s não existe.', $target_taxonomy ) );
+            }
+
+            $result = wc_create_attribute(
+                [
+                    'name'         => $label,
+                    'slug'         => $attribute_slug,
+                    'type'         => 'select',
+                    'order_by'     => $args['order_by'] ?? 'name',
+                    'has_archives' => ! empty( $args['enable_archive'] ),
+                ]
+            );
+
+            if ( is_wp_error( $result ) ) {
+                throw new RuntimeException( $result->get_error_message() );
+            }
+
+            $attribute_id = (int) $result;
+            $this->logger->info( 'Atributo global criado.', [ 'taxonomy' => $target_taxonomy ] );
+
+            // Após criar um novo atributo é necessário recarregar as taxonomias.
+            wc_register_attribute_taxonomies();
+        }
+
+        if ( ! taxonomy_exists( $target_taxonomy ) ) {
+            register_taxonomy( $target_taxonomy, apply_filters( "woocommerce_taxonomy_objects_{$target_taxonomy}", [ 'product' ] ), apply_filters( "woocommerce_taxonomy_args_{$target_taxonomy}", [
+                'labels'       => [ 'name' => $label ],
+                'hierarchical' => false,
+                'show_ui'      => false,
+                'query_var'    => true,
+                'rewrite'      => false,
+            ] ) );
+        }
+
+        return [
+            'attribute_id' => (int) $attribute_id,
+            'taxonomy'     => $target_taxonomy,
+        ];
+    }
+
+    /**
+     * @param array<int, array{local_value:string, term_id?:int, term_slug?:string, term_name?:string, create?:bool}> $terms
+     * @return array<int, array{local_value:string, term_id:int, slug:string, created:bool}>
+     */
+    public function ensure_terms( string $taxonomy, array $terms, bool $allow_creation ): array {
+        $taxonomy = sanitize_key( $taxonomy );
+        if ( ! taxonomy_exists( $taxonomy ) ) {
+            throw new RuntimeException( sprintf( 'Taxonomia %s não registrada.', $taxonomy ) );
+        }
+
+        $results = [];
+
+        foreach ( $terms as $term_config ) {
+            $local_value = $term_config['local_value'];
+            $slug        = sanitize_title( $term_config['term_slug'] ?? $term_config['term_name'] ?? $local_value );
+            $existing    = $this->get_cached_term( $taxonomy, $slug );
+
+            $created = false;
+
+            if ( ! $existing && ! empty( $term_config['term_id'] ) ) {
+                $term = get_term( (int) $term_config['term_id'], $taxonomy );
+                if ( $term && ! is_wp_error( $term ) ) {
+                    $existing = [
+                        'term_id' => (int) $term->term_id,
+                        'slug'    => (string) $term->slug,
+                    ];
+                }
+            }
+
+            if ( ! $existing ) {
+                $term = get_term_by( 'slug', $slug, $taxonomy );
+                if ( $term ) {
+                    $existing = [
+                        'term_id' => (int) $term->term_id,
+                        'slug'    => (string) $term->slug,
+                    ];
+                }
+            }
+
+            if ( ! $existing ) {
+                $should_create = ! empty( $term_config['create'] ) || $allow_creation;
+                if ( ! $should_create ) {
+                    throw new RuntimeException( sprintf( 'Termo "%s" não existe na taxonomia %s.', $local_value, $taxonomy ) );
+                }
+
+                $term_name = $term_config['term_name'] ?? $local_value;
+                $result    = wp_insert_term( $term_name, $taxonomy, [ 'slug' => $slug ] );
+
+                if ( is_wp_error( $result ) ) {
+                    throw new RuntimeException( $result->get_error_message() );
+                }
+
+                $existing = [
+                    'term_id' => (int) $result['term_id'],
+                    'slug'    => (string) $slug,
+                ];
+                $created  = true;
+                $this->logger->info( 'Termo criado.', [ 'taxonomy' => $taxonomy, 'slug' => $slug ] );
+            }
+
+            $this->set_cached_term( $taxonomy, $existing['slug'], $existing );
+
+            $results[] = [
+                'local_value' => $local_value,
+                'term_id'     => $existing['term_id'],
+                'slug'        => $existing['slug'],
+                'created'     => $created,
+            ];
+        }
+
+        return $results;
+    }
+
+    private function get_cached_term( string $taxonomy, string $slug ): ?array {
+        return $this->term_cache[ $taxonomy ][ $slug ] ?? null;
+    }
+
+    private function set_cached_term( string $taxonomy, string $slug, array $data ): void {
+        $this->term_cache[ $taxonomy ][ $slug ] = $data;
+    }
+}

--- a/src/Services/Variation_Service.php
+++ b/src/Services/Variation_Service.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global\Services;
+
+use Evolury\Local2Global\Utils\Logger;
+use WC_Product;
+use WC_Product_Variable;
+use WC_Product_Variation;
+
+class Variation_Service {
+    public function __construct( private Logger $logger ) {}
+
+    /**
+     * @param array<string, string> $slug_map
+     * @return array{updated:int, skipped:int}
+     */
+    public function update_variations( WC_Product $product, string $taxonomy, string $local_name, array $slug_map ): array {
+        if ( ! $product->is_type( 'variable' ) ) {
+            return [ 'updated' => 0, 'skipped' => 0 ];
+        }
+
+        $updated     = 0;
+        $skipped     = 0;
+        $local_key   = 'attribute_' . sanitize_title( $local_name );
+        $target_key  = 'attribute_' . $taxonomy;
+        $variations  = $product->get_children();
+
+        foreach ( $variations as $variation_id ) {
+            $variation = wc_get_product( $variation_id );
+            if ( ! $variation instanceof WC_Product_Variation ) {
+                continue;
+            }
+
+            $current_value = (string) $variation->get_meta( $local_key );
+            if ( '' === $current_value ) {
+                $skipped++;
+                continue;
+            }
+
+            $normalized = $this->normalize_local_value( $current_value );
+            if ( ! isset( $slug_map[ $normalized ] ) ) {
+                $skipped++;
+                continue;
+            }
+
+            $variation->update_meta_data( $target_key, $slug_map[ $normalized ] );
+            $variation->delete_meta_data( $local_key );
+            $variation->save();
+            $updated++;
+        }
+
+        if ( $product instanceof WC_Product_Variable ) {
+            WC_Product_Variable::sync( $product, true );
+        }
+
+        $this->logger->info( 'Variações atualizadas.', [
+            'product_id' => $product->get_id(),
+            'taxonomy'   => $taxonomy,
+            'updated'    => $updated,
+            'skipped'    => $skipped,
+        ] );
+
+        return [ 'updated' => $updated, 'skipped' => $skipped ];
+    }
+
+    private function normalize_local_value( string $value ): string {
+        return strtolower( trim( wc_clean( $value ) ) );
+    }
+}

--- a/src/Setup/Activator.php
+++ b/src/Setup/Activator.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global\Setup;
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+class Activator {
+    public function __construct( private string $plugin_basename ) {}
+
+    public function maybe_declare_hpos_compatibility(): void {
+        if ( ! class_exists( FeaturesUtil::class ) ) {
+            return;
+        }
+
+        $basename = $this->plugin_basename;
+
+        add_action( 'before_woocommerce_init', static function () use ( $basename ): void {
+            FeaturesUtil::declare_compatibility( 'custom_order_tables', $basename, true );
+        } );
+    }
+}

--- a/src/Utils/Logger.php
+++ b/src/Utils/Logger.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global\Utils;
+
+use WC_Logger_Interface;
+
+class Logger {
+    private WC_Logger_Interface $logger;
+
+    public function __construct() {
+        $this->logger = wc_get_logger();
+    }
+
+    public function info( string $message, array $context = [] ): void {
+        $this->logger->info( $message, $this->prepare_context( $context ) );
+    }
+
+    public function warning( string $message, array $context = [] ): void {
+        $this->logger->warning( $message, $this->prepare_context( $context ) );
+    }
+
+    public function error( string $message, array $context = [] ): void {
+        $this->logger->error( $message, $this->prepare_context( $context ) );
+    }
+
+    private function prepare_context( array $context ): array {
+        $context['source'] = 'local2global';
+
+        return $context;
+    }
+}


### PR DESCRIPTION
## Summary
- implement Local 2 Global Attribute Mapper plugin with discovery, mapping, templates, rollback and logging services
- provide admin modal UI, REST endpoints, CLI command and frontend assets to manage the mapping workflow
- document installation and usage steps in the README

## Testing
- php -l local2global-attribute-mapper.php
- find src -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d0ada3f76c83299ccff705907249ca