### PR TITLE
Declare HPOS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 0.1.1
+- Added: HPOS compatibility declaration.

--- a/local2global-attribute-mapper.php
+++ b/local2global-attribute-mapper.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://evolury.com.br
  * Author: Tássio Câmara
  * Author URI: https://evolury.com.br
- * Version: 0.1.0
+ * Version: 0.1.1
  * Requires at least: 6.4
  * Requires PHP: 8.1
  * Text Domain: local2global
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-const VERSION = '0.1.0';
+const VERSION = '0.1.1';
 
 /**
  * Autoloader simplificado baseado em PSR-4.
@@ -52,6 +52,12 @@ function on_activation(): void {
     ( new Setup\Activator( plugin_basename( __FILE__ ) ) )->maybe_declare_hpos_compatibility();
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\\on_activation' );
+
+add_action( 'before_woocommerce_init', static function (): void {
+    if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+    }
+}, 5 );
 
 /**
  * Bootstrap principal do plugin. Executa apenas após o WooCommerce inicializar.

--- a/src/Setup/Activator.php
+++ b/src/Setup/Activator.php
@@ -14,10 +14,8 @@ class Activator {
             return;
         }
 
-        $basename = $this->plugin_basename;
+        $plugin_file = \WP_PLUGIN_DIR . '/' . $this->plugin_basename;
 
-        add_action( 'before_woocommerce_init', static function () use ( $basename ): void {
-            FeaturesUtil::declare_compatibility( 'custom_order_tables', $basename, true );
-        } );
+        FeaturesUtil::declare_compatibility( 'custom_order_tables', $plugin_file, true );
     }
 }


### PR DESCRIPTION
## Summary
- declare HPOS custom order tables compatibility during WooCommerce bootstrap
- align the activation routine with the compatibility declaration and add release notes

## Testing
- php -l local2global-attribute-mapper.php
- php -l src/Setup/Activator.php

------
https://chatgpt.com/codex/tasks/task_e_68d0c5389b2c8329a8879c321e6b6b6e