### PR TITLE
Corrigir erro ao mapear atributo global

### DIFF
--- a/src/Services/Mapping_Service.php
+++ b/src/Services/Mapping_Service.php
@@ -184,7 +184,7 @@ class Mapping_Service {
             $new_attribute->set_visible( $attribute->get_visible() );
             $new_attribute->set_variation( $attribute->get_variation() );
             $new_attribute->set_position( $attribute->get_position() );
-            $new_attribute->set_taxonomy( true );
+            $new_attribute->set_is_taxonomy( true );
 
             $attributes[ $index ] = $new_attribute;
             $replaced              = true;


### PR DESCRIPTION
## Summary
- ajustar a substituição de atributos para marcar corretamente como taxonômicos

## Testing
- php -l src/Services/Mapping_Service.php

------
https://chatgpt.com/codex/tasks/task_e_68d0d030e768832985b0c2d30a44ad78