### PR TITLE
Fix mapping fatal and harden REST handling

### DIFF
--- a/src/Rest/Rest_Controller.php
+++ b/src/Rest/Rest_Controller.php
@@ -6,6 +6,8 @@ namespace Evolury\Local2Global\Rest;
 
 use Evolury\Local2Global\Services\Discovery_Service;
 use Evolury\Local2Global\Services\Mapping_Service;
+use RuntimeException;
+use Throwable;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -40,6 +42,26 @@ class Rest_Controller {
                 'methods'             => 'POST',
                 'callback'            => [ $this, 'map' ],
                 'permission_callback' => [ $this, 'permissions_check' ],
+                'args'                => [
+                    'product_id' => [
+                        'type'              => 'integer',
+                        'required'          => true,
+                        'sanitize_callback' => 'absint',
+                    ],
+                    'mapping'    => [
+                        'type'     => 'array',
+                        'required' => true,
+                    ],
+                    'options'    => [
+                        'type'     => 'object',
+                        'required' => false,
+                    ],
+                    'mode'       => [
+                        'type'              => 'string',
+                        'required'          => false,
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                ],
             ]
         );
 
@@ -71,16 +93,39 @@ class Rest_Controller {
         return new WP_REST_Response( $data );
     }
 
-    public function map( WP_REST_Request $request ) {
+    public function map( WP_REST_Request $request ): WP_REST_Response|WP_Error {
         $product_id = (int) $request->get_param( 'product_id' );
-        $mapping    = (array) $request->get_param( 'mapping' );
-        $options    = (array) $request->get_param( 'options' );
-        $mode       = (string) $request->get_param( 'mode' );
+        $mapping    = $request->get_param( 'mapping' );
+        $options    = $request->get_param( 'options' );
+        $mode       = strtolower( (string) $request->get_param( 'mode' ) );
 
-        if ( 'apply' === $mode ) {
-            $result = $this->mapping->apply( $product_id, $mapping, $options );
-        } else {
-            $result = $this->mapping->dry_run( $product_id, $mapping, $options );
+        if ( $product_id <= 0 ) {
+            return new WP_Error( 'local2global_invalid_product', __( 'Produto inválido.', 'local2global' ), [ 'status' => 400 ] );
+        }
+
+        if ( ! is_array( $mapping ) || empty( $mapping ) ) {
+            return new WP_Error( 'local2global_invalid_mapping', __( 'Mapeamento não informado.', 'local2global' ), [ 'status' => 400 ] );
+        }
+
+        if ( null !== $options && ! is_array( $options ) ) {
+            return new WP_Error( 'local2global_invalid_options', __( 'Formato de opções inválido.', 'local2global' ), [ 'status' => 400 ] );
+        }
+
+        $options = $options ? (array) $options : [];
+
+        try {
+            if ( 'apply' === $mode ) {
+                $result = $this->mapping->apply( $product_id, $mapping, $options );
+            } else {
+                $result = $this->mapping->dry_run( $product_id, $mapping, $options );
+            }
+        } catch ( RuntimeException $exception ) {
+            return new WP_Error( 'local2global_error', $exception->getMessage(), [ 'status' => 400 ] );
+        } catch ( Throwable $exception ) {
+            return new WP_Error( 'local2global_error', __( 'Erro ao processar o mapeamento.', 'local2global' ), [
+                'status'  => 500,
+                'details' => $exception->getMessage(),
+            ] );
         }
 
         return new WP_REST_Response( $result );

--- a/tests/run-tests.php
+++ b/tests/run-tests.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/stubs/woocommerce.php';
+require __DIR__ . '/../src/Services/Mapping_Service.php';
+require __DIR__ . '/../src/Services/Variation_Service.php';
+require __DIR__ . '/../src/Utils/Logger.php';
+
+use Evolury\Local2Global\Services\Mapping_Service;
+use Evolury\Local2Global\Services\Variation_Service;
+use Evolury\Local2Global\Utils\Logger;
+
+final class TestRunner {
+    private int $assertions = 0;
+
+    public function run(): void {
+        $this->testReplaceAttributeWithObject();
+        $this->testReplaceAttributeWithLegacyArray();
+        $this->testUpdateVariations();
+
+        echo sprintf( "All %d assertions passed.\n", $this->assertions );
+    }
+
+    private function assertTrue( bool $condition, string $message = 'Assertion failed' ): void {
+        if ( ! $condition ) {
+            throw new RuntimeException( $message );
+        }
+
+        $this->assertions++;
+    }
+
+    private function assertSame( $expected, $actual, string $message = '' ): void {
+        if ( $expected !== $actual ) {
+            $message = $message ?: sprintf( 'Expected %s, got %s', var_export( $expected, true ), var_export( $actual, true ) );
+            throw new RuntimeException( $message );
+        }
+
+        $this->assertions++;
+    }
+
+    private function createMappingService(): Mapping_Service {
+        $reflection = new ReflectionClass( Mapping_Service::class );
+        /** @var Mapping_Service $service */
+        $service    = $reflection->newInstanceWithoutConstructor();
+
+        return $service;
+    }
+
+    private function invokeReplaceAttribute( Mapping_Service $service, WC_Product $product, string $local, string $taxonomy, int $attribute_id, array $term_ids ): bool {
+        $method = new ReflectionMethod( Mapping_Service::class, 'replace_attribute' );
+        $method->setAccessible( true );
+
+        return (bool) $method->invoke( $service, $product, $local, $taxonomy, $attribute_id, $term_ids );
+    }
+
+    private function testReplaceAttributeWithObject(): void {
+        global $test_object_terms;
+        $test_object_terms = [];
+
+        $attribute = new WC_Product_Attribute();
+        $attribute->set_name( 'Cor' );
+        $attribute->set_position( 1 );
+        $attribute->set_visible( true );
+        $attribute->set_variation( true );
+
+        $product = new WC_Product( [ 'cor' => $attribute ], 10 );
+
+        $service = $this->createMappingService();
+        $result  = $this->invokeReplaceAttribute( $service, $product, 'Cor', 'pa_cor', 9, [ 11, 12 ] );
+
+        $this->assertTrue( $result, 'Attribute should be replaced' );
+
+        $attributes = $product->get_attributes();
+        $this->assertTrue( isset( $attributes['pa_cor'] ), 'Attribute key should be taxonomy' );
+
+        /** @var WC_Product_Attribute $replaced */
+        $replaced = $attributes['pa_cor'];
+        $this->assertSame( 'pa_cor', $replaced->get_name(), 'Attribute name should be taxonomy' );
+        $this->assertSame( [ 11, 12 ], $replaced->get_options(), 'Attribute options must be term ids' );
+        $this->assertTrue( $replaced->get_taxonomy(), 'Attribute must be taxonomy' );
+        $this->assertTrue( $replaced->get_visible(), 'Visibility should be preserved' );
+        $this->assertTrue( $replaced->get_variation(), 'Variation flag should be preserved' );
+    }
+
+    private function testReplaceAttributeWithLegacyArray(): void {
+        $legacy_attribute = [
+            'name'         => 'Cor',
+            'value'        => 'Azul | Verde',
+            'is_visible'   => 1,
+            'is_variation' => 0,
+            'is_taxonomy'  => 0,
+        ];
+
+        $product = new WC_Product( [ 'cor' => $legacy_attribute ], 11 );
+
+        $service = $this->createMappingService();
+        $result  = $this->invokeReplaceAttribute( $service, $product, 'Cor', 'pa_cor', 9, [ 14 ] );
+
+        $this->assertTrue( $result, 'Legacy attribute should be replaced' );
+        $attributes = $product->get_attributes();
+        $this->assertTrue( isset( $attributes['pa_cor'] ), 'Legacy attribute should be converted to taxonomy' );
+
+        /** @var WC_Product_Attribute $replaced */
+        $replaced = $attributes['pa_cor'];
+        $this->assertSame( [ 14 ], $replaced->get_options(), 'Legacy attribute options should be replaced with term ids' );
+        $this->assertSame( 0, $replaced->get_position(), 'Legacy position should default to zero when missing' );
+    }
+
+    private function testUpdateVariations(): void {
+        global $test_products;
+        $test_products = [];
+        WC_Product_Variable::$synced_products = [];
+
+        $logger    = new Logger();
+        $service   = new Variation_Service( $logger );
+        $product   = new WC_Product_Variable( [], 21 );
+        $variation = new WC_Product_Variation( 2101 );
+        $variation->update_meta_data( 'attribute_cor', 'Azul' );
+        register_test_product( $variation );
+
+        $product->set_children( [ $variation->get_id() ] );
+        register_test_product( $product );
+
+        $result = $service->update_variations( $product, 'pa_cor', 'Cor', [ 'azul' => 'azul-marinho' ] );
+
+        $this->assertSame( [ 'updated' => 1, 'skipped' => 0 ], $result, 'Variation update counters mismatch' );
+
+        $meta = $variation->get_all_meta();
+        $this->assertSame( 'azul-marinho', $meta['attribute_pa_cor'] ?? null, 'Variation meta should be updated with slug' );
+        $this->assertTrue( ! isset( $meta['attribute_cor'] ), 'Legacy variation meta should be removed' );
+        $this->assertTrue( in_array( $product->get_id(), WC_Product_Variable::$synced_products, true ), 'Variable product should be synced' );
+    }
+}
+
+( new TestRunner() )->run();

--- a/tests/stubs/woocommerce.php
+++ b/tests/stubs/woocommerce.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+interface WC_Logger_Interface {
+    public function emergency( $message, array $context = [] );
+
+    public function alert( $message, array $context = [] );
+
+    public function critical( $message, array $context = [] );
+
+    public function error( $message, array $context = [] );
+
+    public function warning( $message, array $context = [] );
+
+    public function notice( $message, array $context = [] );
+
+    public function info( $message, array $context = [] );
+
+    public function debug( $message, array $context = [] );
+
+    public function log( $level, $message, array $context = [] );
+}
+
+class WC_Product {
+    protected array $attributes = [];
+    protected bool $saved = false;
+    protected bool $is_variable = false;
+    protected int $id;
+    protected array $children = [];
+
+    public function __construct( array $attributes = [], int $id = 0 ) {
+        $this->attributes = $attributes;
+        $this->id         = $id > 0 ? $id : random_int( 1, 1000 );
+    }
+
+    public function get_attributes(): array {
+        return $this->attributes;
+    }
+
+    public function set_attributes( array $attributes ): void {
+        $this->attributes = $attributes;
+    }
+
+    public function save(): void {
+        $this->saved = true;
+    }
+
+    public function was_saved(): bool {
+        return $this->saved;
+    }
+
+    public function is_type( string $type ): bool {
+        return 'variable' === $type && $this->is_variable;
+    }
+
+    public function set_variable( bool $value ): void {
+        $this->is_variable = $value;
+    }
+
+    public function set_children( array $children ): void {
+        $this->children = $children;
+    }
+
+    public function get_children(): array {
+        return $this->children;
+    }
+
+    public function get_id(): int {
+        return $this->id;
+    }
+}
+
+class WC_Product_Variable extends WC_Product {
+    public static array $synced_products = [];
+
+    public function __construct( array $attributes = [], int $id = 0 ) {
+        parent::__construct( $attributes, $id );
+        $this->set_variable( true );
+    }
+
+    public static function sync( WC_Product $product, bool $children = true ): void {
+        self::$synced_products[] = $product->get_id();
+    }
+}
+
+class WC_Product_Variation extends WC_Product {
+    private array $meta = [];
+
+    public function __construct( int $id ) {
+        parent::__construct( [], $id );
+    }
+
+    public function get_meta( string $key ): string {
+        return $this->meta[ $key ] ?? '';
+    }
+
+    public function update_meta_data( string $key, string $value ): void {
+        $this->meta[ $key ] = $value;
+    }
+
+    public function delete_meta_data( string $key ): void {
+        unset( $this->meta[ $key ] );
+    }
+
+    public function get_all_meta(): array {
+        return $this->meta;
+    }
+}
+
+class WC_Product_Attribute {
+    private int $id = 0;
+    private string $name = '';
+    private array $options = [];
+    private int $position = 0;
+    private bool $visible = false;
+    private bool $variation = false;
+    private bool $is_taxonomy = false;
+
+    public function set_id( int $id ): void {
+        $this->id = $id;
+    }
+
+    public function get_id(): int {
+        return $this->id;
+    }
+
+    public function set_name( string $name ): void {
+        $this->name = $name;
+    }
+
+    public function get_name(): string {
+        return $this->name;
+    }
+
+    public function set_options( array $options ): void {
+        $this->options = $options;
+    }
+
+    public function get_options(): array {
+        return $this->options;
+    }
+
+    public function set_position( int $position ): void {
+        $this->position = $position;
+    }
+
+    public function get_position(): int {
+        return $this->position;
+    }
+
+    public function set_visible( bool $visible ): void {
+        $this->visible = $visible;
+    }
+
+    public function get_visible(): bool {
+        return $this->visible;
+    }
+
+    public function set_variation( bool $variation ): void {
+        $this->variation = $variation;
+    }
+
+    public function get_variation(): bool {
+        return $this->variation;
+    }
+
+    public function set_taxonomy( bool $value ): void {
+        $this->is_taxonomy = $value;
+    }
+
+    public function get_taxonomy(): bool {
+        return $this->is_taxonomy;
+    }
+}
+
+function sanitize_title( string $title ): string {
+    $normalized = strtolower( $title );
+    $normalized = preg_replace( '/[^a-z0-9_\-]+/u', '-', $normalized );
+    return trim( (string) $normalized, '-' );
+}
+
+function sanitize_key( string $key ): string {
+    $key = strtolower( $key );
+    return preg_replace( '/[^a-z0-9_]/', '', $key );
+}
+
+function sanitize_text_field( string $value ): string {
+    return trim( filter_var( $value, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW ) );
+}
+
+function absint( $value ): int {
+    return abs( (int) $value );
+}
+
+function wc_clean( $var ) {
+    if ( is_string( $var ) ) {
+        return trim( $var );
+    }
+
+    return $var;
+}
+
+function wc_get_text_attributes( string $value ): array {
+    if ( '' === $value ) {
+        return [];
+    }
+
+    $parts = array_map( 'trim', explode( '|', $value ) );
+    return array_values( array_filter( $parts, static fn( string $item ): bool => '' !== $item ) );
+}
+
+function __ ( string $text ): string {
+    return $text;
+}
+
+function taxonomy_exists( string $taxonomy ): bool {
+    global $test_registered_taxonomies;
+
+    return in_array( $taxonomy, $test_registered_taxonomies, true );
+}
+
+function wp_set_object_terms( int $product_id, array $term_ids, string $taxonomy, bool $append ): void {
+    global $test_object_terms;
+
+    $test_object_terms[] = [
+        'product_id' => $product_id,
+        'terms'      => $term_ids,
+        'taxonomy'   => $taxonomy,
+        'append'     => $append,
+    ];
+}
+
+function wc_delete_product_transients( int $product_id ): void {
+    // noop for tests.
+}
+
+function wc_get_logger(): WC_Logger_Interface {
+    return new class() implements WC_Logger_Interface {
+        public array $logs = [];
+
+        public function emergency( $message, array $context = [] ) {}
+
+        public function alert( $message, array $context = [] ) {}
+
+        public function critical( $message, array $context = [] ) {}
+
+        public function error( $message, array $context = [] ): void {
+            $this->logs[] = [ 'level' => 'error', 'message' => (string) $message, 'context' => $context ];
+        }
+
+        public function warning( $message, array $context = [] ): void {
+            $this->logs[] = [ 'level' => 'warning', 'message' => (string) $message, 'context' => $context ];
+        }
+
+        public function notice( $message, array $context = [] ) {}
+
+        public function info( $message, array $context = [] ): void {
+            $this->logs[] = [ 'level' => 'info', 'message' => $message, 'context' => $context ];
+        }
+
+        public function debug( $message, array $context = [] ) {}
+
+        public function log( $level, $message, array $context = [] ) {}
+    };
+}
+
+function wc_get_product( int $product_id ): ?WC_Product {
+    global $test_products;
+
+    return $test_products[ $product_id ] ?? null;
+}
+
+function register_test_product( WC_Product $product ): void {
+    global $test_products;
+
+    $test_products[ $product->get_id() ] = $product;
+}
+
+$test_registered_taxonomies = [ 'pa_cor', 'pa_tamanho' ];
+$test_products              = [];
+$test_object_terms          = [];


### PR DESCRIPTION
## Summary
- normalize and rebuild product attributes when mapping local attributes to taxonomies, ensuring term IDs are assigned and taxonomy existence is validated
- improve REST controller validation and error handling so mapping requests return controlled WP_Error responses
- add lightweight PHP tests that cover attribute replacement from legacy arrays and variation synchronization

## Testing
- php tests/run-tests.php

------
https://chatgpt.com/codex/tasks/task_e_68d0d3661d7c8329891c05bdeec00f56