### PR TITLE
Improve error propagation and logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## 0.1.1
 - Added: HPOS compatibility declaration.
+- Improved: REST and admin UI now expose root-cause errors with correlation IDs, structured logging, payload validation and status codes.

--- a/local2global-attribute-mapper.php
+++ b/local2global-attribute-mapper.php
@@ -24,6 +24,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 const VERSION = '0.1.1';
 
+if ( ! defined( 'L2G_DEBUG' ) ) {
+    define( 'L2G_DEBUG', defined( 'WP_DEBUG' ) && WP_DEBUG );
+}
+
 /**
  * Autoloader simplificado baseado em PSR-4.
  *

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -69,7 +69,7 @@ class Plugin {
             $this->admin_ui->hooks();
         }
 
-        $this->rest = new Rest_Controller( $this->discovery, $this->mapping );
+        $this->rest = new Rest_Controller( $this->discovery, $this->mapping, $this->logger );
         add_action( 'rest_api_init', [ $this->rest, 'register_routes' ] );
 
         if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/src/Services/Variation_Service.php
+++ b/src/Services/Variation_Service.php
@@ -16,7 +16,7 @@ class Variation_Service {
      * @param array<string, string> $slug_map
      * @return array{updated:int, skipped:int}
      */
-    public function update_variations( WC_Product $product, string $taxonomy, string $local_name, array $slug_map ): array {
+    public function update_variations( WC_Product $product, string $taxonomy, string $local_name, array $slug_map, ?string $corr_id = null ): array {
         if ( ! $product->is_type( 'variable' ) ) {
             return [ 'updated' => 0, 'skipped' => 0 ];
         }
@@ -55,12 +55,19 @@ class Variation_Service {
             WC_Product_Variable::sync( $product, true );
         }
 
-        $this->logger->info( 'Variações atualizadas.', [
+        $context = [
             'product_id' => $product->get_id(),
             'taxonomy'   => $taxonomy,
+            'local_attr' => $local_name,
             'updated'    => $updated,
             'skipped'    => $skipped,
-        ] );
+        ];
+
+        if ( $corr_id ) {
+            $context['corr_id'] = $corr_id;
+        }
+
+        $this->logger->info( 'Variações atualizadas.', $context );
 
         return [ 'updated' => $updated, 'skipped' => $skipped ];
     }

--- a/src/Utils/Logger.php
+++ b/src/Utils/Logger.php
@@ -9,8 +9,29 @@ use WC_Logger_Interface;
 class Logger {
     private WC_Logger_Interface $logger;
 
+    /** @var array<int, array<string, mixed>> */
+    private array $context_stack = [];
+
     public function __construct() {
         $this->logger = wc_get_logger();
+    }
+
+    public function scoped( array $context, callable $callback ) {
+        $this->push_context( $context );
+
+        try {
+            return $callback( $this );
+        } finally {
+            $this->pop_context();
+        }
+    }
+
+    public function push_context( array $context ): void {
+        $this->context_stack[] = $context;
+    }
+
+    public function pop_context(): void {
+        array_pop( $this->context_stack );
     }
 
     public function info( string $message, array $context = [] ): void {
@@ -26,7 +47,24 @@ class Logger {
     }
 
     private function prepare_context( array $context ): array {
+        $stacked = [];
+        foreach ( $this->context_stack as $layer ) {
+            $stacked = array_merge( $stacked, $layer );
+        }
+
+        $context = array_merge( $stacked, $context );
         $context['source'] = 'local2global';
+
+        if ( isset( $context['exception'] ) && $context['exception'] instanceof \Throwable ) {
+            $exception             = $context['exception'];
+            $context['exception']  = [
+                'class'   => get_class( $exception ),
+                'message' => $exception->getMessage(),
+            ];
+            if ( defined( 'L2G_DEBUG' ) && L2G_DEBUG ) {
+                $context['trace'] = $exception->getTraceAsString();
+            }
+        }
 
         return $context;
     }

--- a/tests/stubs/woocommerce.php
+++ b/tests/stubs/woocommerce.php
@@ -2,6 +2,38 @@
 
 declare(strict_types=1);
 
+class WP_Error {
+    private string $code;
+    private string $message;
+    private array $data;
+
+    public function __construct( string $code, string $message = '', array $data = [] ) {
+        $this->code    = $code;
+        $this->message = $message;
+        $this->data    = $data;
+    }
+
+    public function get_error_code(): string {
+        return $this->code;
+    }
+
+    public function get_error_message(): string {
+        return $this->message;
+    }
+
+    public function get_error_data(): array {
+        return $this->data;
+    }
+
+    public function add_data( array $data ): void {
+        $this->data = $data;
+    }
+}
+
+function is_wp_error( $value ): bool {
+    return $value instanceof WP_Error;
+}
+
 interface WC_Logger_Interface {
     public function emergency( $message, array $context = [] );
 
@@ -236,33 +268,39 @@ function wc_delete_product_transients( int $product_id ): void {
 }
 
 function wc_get_logger(): WC_Logger_Interface {
-    return new class() implements WC_Logger_Interface {
-        public array $logs = [];
+    global $test_wc_logger;
 
-        public function emergency( $message, array $context = [] ) {}
+    if ( ! $test_wc_logger ) {
+        $test_wc_logger = new class() implements WC_Logger_Interface {
+            public array $logs = [];
 
-        public function alert( $message, array $context = [] ) {}
+            public function emergency( $message, array $context = [] ) {}
 
-        public function critical( $message, array $context = [] ) {}
+            public function alert( $message, array $context = [] ) {}
 
-        public function error( $message, array $context = [] ): void {
-            $this->logs[] = [ 'level' => 'error', 'message' => (string) $message, 'context' => $context ];
-        }
+            public function critical( $message, array $context = [] ) {}
 
-        public function warning( $message, array $context = [] ): void {
-            $this->logs[] = [ 'level' => 'warning', 'message' => (string) $message, 'context' => $context ];
-        }
+            public function error( $message, array $context = [] ): void {
+                $this->logs[] = [ 'level' => 'error', 'message' => (string) $message, 'context' => $context ];
+            }
 
-        public function notice( $message, array $context = [] ) {}
+            public function warning( $message, array $context = [] ): void {
+                $this->logs[] = [ 'level' => 'warning', 'message' => (string) $message, 'context' => $context ];
+            }
 
-        public function info( $message, array $context = [] ): void {
-            $this->logs[] = [ 'level' => 'info', 'message' => $message, 'context' => $context ];
-        }
+            public function notice( $message, array $context = [] ) {}
 
-        public function debug( $message, array $context = [] ) {}
+            public function info( $message, array $context = [] ): void {
+                $this->logs[] = [ 'level' => 'info', 'message' => $message, 'context' => $context ];
+            }
 
-        public function log( $level, $message, array $context = [] ) {}
-    };
+            public function debug( $message, array $context = [] ) {}
+
+            public function log( $level, $message, array $context = [] ) {}
+        };
+    }
+
+    return $test_wc_logger;
 }
 
 function wc_get_product( int $product_id ): ?WC_Product {
@@ -280,3 +318,4 @@ function register_test_product( WC_Product $product ): void {
 $test_registered_taxonomies = [ 'pa_cor', 'pa_tamanho' ];
 $test_products              = [];
 $test_object_terms          = [];
+$test_wc_logger             = null;


### PR DESCRIPTION
## Summary
- add request correlation IDs and structured logging across the REST controller, services and CLI
- harden Mapping_Service with payload validation, controlled rollbacks, and explicit WP_Error propagation
- surface backend error details (message + corr_id) in the admin modal and extend the PHP test suite for success, validation and failure flows

## Testing
- `php tests/run-tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68d0d8cf87408329afd47991a0f7f2c0