### PR TITLE
Fix dry-run preview rendering in admin modal

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -393,15 +393,18 @@
             return;
         }
 
-        if (state.dryRun.errors.length) {
-            const errors = document.createElement('div');
-            errors.className = 'notice notice-error';
-            errors.innerHTML = '<p><strong>' + __('Problemas encontrados:', 'local2global') + '</strong></p><ul>' +
-                state.dryRun.errors.map((err) => '<li>' + escapeHtml(err) + '</li>').join('') + '</ul>';
-            container.appendChild(errors);
+        const preview = state.dryRun;
+        const issues = Array.isArray(preview?.errors) ? preview.errors : [];
+
+        if (issues.length) {
+            const errorsBox = document.createElement('div');
+            errorsBox.className = 'notice notice-error';
+            errorsBox.innerHTML = '<p><strong>' + __('Problemas encontrados:', 'local2global') + '</strong></p><ul>' +
+                issues.map((err) => '<li>' + escapeHtml(err) + '</li>').join('') + '</ul>';
+            container.appendChild(errorsBox);
         }
 
-        state.dryRun.attributes.forEach((attr) => {
+        (preview.attributes || []).forEach((attr) => {
             const section = document.createElement('section');
             section.innerHTML = '<h3>' + escapeHtml(attr.local_label) + '</h3>';
             const summary = document.createElement('div');
@@ -518,7 +521,8 @@
                 mode: 'dry-run',
             },
         }).then((result) => {
-            state.dryRun = result;
+            state.dryRun = result?.result || result;
+            state.dryRunCorrId = result?.corr_id || null;
         }).catch((error) => {
             const formatted = formatApiError(error);
             window.alert(formatted.message);


### PR DESCRIPTION
## Summary
- normalize the dry-run API response handling so the preview step receives the expected data
- guard the dry-run rendering logic against missing fields when showing errors and summaries

## Testing
- php tests/run-tests.php

------
https://chatgpt.com/codex/tasks/task_e_68d15f05d790832995ac41fcce42820d