### PR TITLE
Correções e melhorias: mapeamento, logs e variações

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,131 @@ wp local2global map --product=123 --attr="Cor:pa_cor" --term="Azul:azul" --creat
 - WooCommerce 8.6+
 - PHP 8.1+
 
+## Debug & Teste
+
+### Endpoints REST
+
+Descoberta de atributos locais de um produto:
+
+```bash
+curl -s -H "Accept: application/json" -H "Cookie: $(wp user session-token 1 2>/dev/null || echo 'USE_SESSAO_ADMIN')" \
+	"https://seusite.test/wp-json/local2global/v1/discover?product_id=123" | jq .
+```
+
+Aplicação do mapeamento (exemplo com um atributo):
+
+```bash
+curl -s -X POST "https://seusite.test/wp-json/local2global/v1/map" \
+	-H "Content-Type: application/json" \
+	-H "Cookie: (sessao admin)" \
+	-d '{
+		"product_id": 123,
+		"mode": "apply",
+		"mapping": [
+			{
+				"local_attr": "Cor",
+				"local_label": "Cor",
+				"target_tax": "pa_cor",
+				"create_attribute": true,
+				"terms": [
+					{ "local_value": "Azul", "term_slug": "azul", "create": true },
+					{ "local_value": "Vermelho", "term_slug": "vermelho", "create": true }
+				]
+			}
+		],
+		"options": { "auto_create_terms": true, "update_variations": true, "create_backup": true }
+	}' | jq .
+```
+
+Para dry-run (pré-visualização), use `"mode": "dry_run"`.
+
+### Logs
+
+Os logs são gravados no logger do WooCommerce (`WooCommerce > Status > Logs`). Busque por entradas com `source=local2global`.
+
+Principais marcadores de log:
+
+| Evento | Descrição |
+|--------|-----------|
+| `apply.start` | Início da aplicação de um lote de atributos |
+| `attribute.process.start` / `end` | Processamento de um atributo local específico |
+| `replace_attribute.scan` | Lista de candidatos encontrados ao substituir o atributo |
+| `replace_attribute.success` | Substituição concluída para taxonomia alvo |
+| `variation.slug_map_missing` | Valor de variação sem correspondência no novo atributo global |
+| `apply.term_assignment` | Atribuição de termos ao produto (produto principal) |
+| `apply.completed` | Resumo final (termos criados, existentes, variações) |
+| `permission.denied` | Falha de permissão em endpoint REST |
+
+### Diagnóstico de Falhas Comuns
+
+- Atributo não substituído: Verifique `replace_attribute.scan` e se o nome normalizado do local aparece; caso não, o nome no produto pode estar diferente (maiúsculas, espaços, acentos).
+- Termos não criados: Confirme se `auto_create_terms` ou `create` está marcado no mapeamento; veja logs de `Termo criado.`.
+- Variações não atualizadas: Cheque `variation.slug_map_missing` e valide se os valores originais contêm acentos ou variações de grafia não normalizadas.
+- 403 em REST: Usuário precisa de `manage_woocommerce` ou `edit_products`.
+
+### WP-CLI
+
+Execução básica (exemplo conceitual – implementação CLI pode variar):
+
+```bash
+wp local2global map --product=123 \
+	--attr="Cor:pa_cor" \
+	--term="Azul:azul" \
+	--term="Vermelho:vermelho" \
+	--create-missing=1 --apply-variations=1 --backup=1
+```
+
+### Subcomando de Simulação
+
+Cria automaticamente um produto variável de teste com atributos locais e executa o fluxo de mapeamento (dry-run ou apply):
+
+```bash
+wp local2global simulate \
+	--attr="Cor:pa_cor" \
+	--val="Azul:azul" --val="Vermelho:vermelho" \
+	--variations=2 \
+	--dry-run=0
+```
+
+Parâmetros:
+- `--attr local:pa_slug` (repetível) – cria atributo local e mapeia para taxonomia alvo (criando-a se necessário).
+- `--val valor_local:slug_global` (repetível) – valores e slugs alvo (criados se não existirem).
+- `--variations N` – quantas variações gerar (baseadas no primeiro atributo).
+- `--dry-run=1` – só simula sem aplicar.
+
+Após execução, verifique logs com `source=local2global` para detalhes (`apply.completed`).
+
+### Reprocessar Variações (CLI)
+
+Reaplica apenas o ajuste das variações para taxonomias já mapeadas:
+
+```bash
+wp local2global variations-update --product=123
+wp local2global variations-update --product=123 --tax=pa_cor --tax=pa_tamanho
+```
+
+### Endpoint REST de Reprocessamento de Variações
+
+`POST /wp-json/local2global/v1/variations/update`
+
+Body exemplo:
+```json
+{
+	"product_id": 123,
+	"taxonomies": ["pa_cor", "pa_tamanho"]
+}
+```
+Resposta:
+```json
+{
+	"ok": true,
+	"corr_id": "...",
+	"result": { "product_id":123, "taxonomies": { "pa_cor":{"updated":1,"skipped":2} } }
+}
+```
+
+### Estratégia de Normalização
+
+Todos os valores locais e de variações passam por normalização unificada (classe `Value_Normalizer`) removendo acentos e diacríticos para casar com slugs de termos.
+
+

--- a/src/Cli/CLI_Command.php
+++ b/src/Cli/CLI_Command.php
@@ -8,6 +8,11 @@ use Evolury\Local2Global\Services\Mapping_Service;
 use WP_CLI_Command;
 use WP_Query;
 
+/**
+ * Nota: Este comando usa funções globais do WordPress (wp_insert_post, update_post_meta, etc.)
+ * que estarão disponíveis somente no runtime WP-CLI. O analisador estático pode sinalizar
+ * como indefinidas dentro do namespace.
+ */
 class CLI_Command extends WP_CLI_Command {
     public function __construct( private Mapping_Service $mapping ) {}
 
@@ -127,5 +132,164 @@ class CLI_Command extends WP_CLI_Command {
                 \WP_CLI::success( sprintf( 'Mapeamento aplicado ao produto %d (%s): %s', $product_id, $corr_id, wp_json_encode( $result ) ) );
             }
         }
+    }
+
+    /**
+     * Cria um produto variável de teste com atributos locais e executa um mapeamento completo.
+     *
+     * ## OPTIONS
+     *
+     * [--attr=<nome_local:pa_slug>]
+     * : Define o atributo local e a taxonomia alvo (default: "Cor:pa_cor"). Pode repetir.
+     *
+     * [--val=<valor_local:slug_global>]
+     * : Define um valor local e slug destino (p. ex. "Azul:azul"). Pode repetir.
+     *
+     * [--variations=<n>]
+     * : Quantidade de variações a gerar (default: 2).
+     *
+     * [--dry-run=<0|1>]
+     * : Se definido como 1, apenas simula.
+     */
+    public function simulate( array $args, array $assoc_args ): void {
+        $attrs_input = (array) ( $assoc_args['attr'] ?? [ 'Cor:pa_cor' ] );
+        $vals_input  = (array) ( $assoc_args['val'] ?? [ 'Azul:azul', 'Vermelho:vermelho' ] );
+        $variations_qtd = (int) ( $assoc_args['variations'] ?? 2 );
+
+        if ( $variations_qtd < 1 ) {
+            $variations_qtd = 1;
+        }
+
+        $mapping = [];
+        $terms_template = [];
+        foreach ( $vals_input as $pair ) {
+            [ $local_value, $slug ] = array_pad( explode( ':', (string) $pair, 2 ), 2, '' );
+            if ( '' === $local_value || '' === $slug ) { continue; }
+            $terms_template[] = [
+                'local_value' => $local_value,
+                'term_slug'   => $slug,
+                'term_name'   => $local_value,
+                'create'      => true,
+            ];
+        }
+
+        foreach ( $attrs_input as $a_pair ) {
+            [ $local_attr, $target_tax ] = array_pad( explode( ':', (string) $a_pair, 2 ), 2, '' );
+            if ( '' === $local_attr || '' === $target_tax ) { continue; }
+            $mapping[] = [
+                'local_attr'       => $local_attr,
+                'local_label'      => $local_attr,
+                'target_tax'       => $target_tax,
+                'target_label'     => $local_attr,
+                'create_attribute' => true,
+                'terms'            => $terms_template,
+                'save_template'    => true,
+            ];
+        }
+
+        if ( empty( $mapping ) ) {
+            \WP_CLI::error( 'Nenhum atributo válido informado.' );
+        }
+
+        // Cria produto variável
+        $product_id = wp_insert_post( [
+            'post_type'   => 'product',
+            'post_status' => 'publish',
+            'post_title'  => 'Produto Teste Local2Global ' . wp_generate_password( 6, false ),
+        ] );
+        if ( ! $product_id || is_wp_error( $product_id ) ) {
+            \WP_CLI::error( 'Falha ao criar produto de teste.' );
+        }
+
+        // Monta atributos locais no produto (meta `_product_attributes`).
+        $attr_meta = [];
+        foreach ( $mapping as $index => $map ) {
+            $values = array_map( static fn( $t ) => $t['local_value'], $map['terms'] );
+            $attr_meta[ sanitize_title( $map['local_attr'] ) ] = [
+                'name'         => $map['local_attr'],
+                'value'        => implode( ' | ', $values ),
+                'position'     => $index,
+                'is_visible'   => 1,
+                'is_variation' => 1,
+                'is_taxonomy'  => 0,
+            ];
+        }
+        update_post_meta( $product_id, '_product_attributes', $attr_meta );
+
+        // Cria variações simples baseadas nos valores (limitado ao primeiro atributo para simplicidade).
+        $first_attr = $mapping[0]['local_attr'];
+        $values     = array_map( static fn( $t ) => $t['local_value'], $mapping[0]['terms'] );
+        $loop       = 0;
+        foreach ( $values as $val ) {
+            if ( $loop >= $variations_qtd ) { break; }
+            $variation_id = wp_insert_post( [
+                'post_type'   => 'product_variation',
+                'post_status' => 'publish',
+                'post_parent' => $product_id,
+                'menu_order'  => $loop,
+                'post_title'  => 'Variação ' . $val,
+            ] );
+            if ( $variation_id && ! is_wp_error( $variation_id ) ) {
+                update_post_meta( $variation_id, 'attribute_' . sanitize_title( $first_attr ), $val );
+                update_post_meta( $variation_id, '_price', 10 + $loop );
+                update_post_meta( $variation_id, '_regular_price', 10 + $loop );
+            }
+            $loop++;
+        }
+
+        \WP_CLI::log( sprintf( 'Produto de teste criado: %d', $product_id ) );
+
+        $options = [
+            'auto_create_terms' => true,
+            'update_variations' => true,
+            'create_backup'     => empty( $assoc_args['dry-run'] ),
+        ];
+
+        $corr_id = uniqid( 'l2g_sim_', true );
+        if ( ! empty( $assoc_args['dry-run'] ) ) {
+            $result = $this->mapping->dry_run( (int) $product_id, $mapping, $options, $corr_id );
+            if ( is_wp_error( $result ) ) {
+                $data = $result->get_error_data();
+                \WP_CLI::warning( sprintf( 'Dry-run falhou (%s): %s', $data['corr_id'] ?? $corr_id, $result->get_error_message() ) );
+            } else {
+                \WP_CLI::success( sprintf( 'Dry-run concluído (%s): %s', $corr_id, wp_json_encode( $result ) ) );
+            }
+        } else {
+            $result = $this->mapping->apply( (int) $product_id, $mapping, $options, $corr_id );
+            if ( is_wp_error( $result ) ) {
+                $data = $result->get_error_data();
+                \WP_CLI::warning( sprintf( 'Aplicação falhou (%s): %s', $data['corr_id'] ?? $corr_id, $result->get_error_message() ) );
+            } else {
+                \WP_CLI::success( sprintf( 'Mapeamento aplicado (%s): %s', $corr_id, wp_json_encode( $result ) ) );
+            }
+        }
+
+        \WP_CLI::log( 'Verifique logs WooCommerce (source=local2global) para detalhes.' );
+    }
+
+    /**
+     * Reprocessa apenas variações de um produto já mapeado.
+     *
+     * ## OPTIONS
+     *
+     * --product=<id>
+     * : ID do produto variável.
+     *
+     * [--tax=<pa_tax>]
+     * : Limitar a uma ou mais taxonomias (pode repetir).
+     */
+    public function variations_update( array $args, array $assoc_args ): void {
+        $product_id = (int) ( $assoc_args['product'] ?? 0 );
+        if ( $product_id <= 0 ) {
+            \WP_CLI::error( 'Informe --product=<id>.' );
+        }
+        $tax_filters = (array) ( $assoc_args['tax'] ?? [] );
+        $corr_id = uniqid( 'l2g_cli_var_', true );
+        $result  = $this->mapping->update_variations_only( $product_id, $tax_filters ?: null, $corr_id );
+        if ( is_wp_error( $result ) ) {
+            \WP_CLI::warning( sprintf( 'Falha (%s): %s', $corr_id, $result->get_error_message() ) );
+            return;
+        }
+        \WP_CLI::success( sprintf( 'Variações reprocessadas (%s): %s', $corr_id, wp_json_encode( $result ) ) );
     }
 }

--- a/src/Services/Variation_Service.php
+++ b/src/Services/Variation_Service.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Evolury\Local2Global\Services;
 
 use Evolury\Local2Global\Utils\Logger;
+use Evolury\Local2Global\Utils\Value_Normalizer;
 use WC_Product;
 use WC_Product_Variable;
 use WC_Product_Variation;
@@ -39,8 +40,9 @@ class Variation_Service {
                 continue;
             }
 
-            $normalized = $this->normalize_local_value( $current_value );
+            $normalized = Value_Normalizer::normalize( $current_value );
             if ( ! isset( $slug_map[ $normalized ] ) ) {
+                $this->logger->warning( 'variation.slug_map_missing', [ 'variation_id' => $variation_id, 'raw_value' => $current_value, 'normalized' => $normalized ] );
                 $skipped++;
                 continue;
             }
@@ -72,7 +74,5 @@ class Variation_Service {
         return [ 'updated' => $updated, 'skipped' => $skipped ];
     }
 
-    private function normalize_local_value( string $value ): string {
-        return strtolower( trim( wc_clean( $value ) ) );
-    }
+    private function normalize_local_value( string $value ): string { return Value_Normalizer::normalize( $value ); }
 }

--- a/src/Utils/Value_Normalizer.php
+++ b/src/Utils/Value_Normalizer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolury\Local2Global\Utils;
+
+class Value_Normalizer {
+    public static function normalize( string $value ): string {
+        $clean = strtolower( trim( wc_clean( $value ) ) );
+        if ( class_exists( '\\Normalizer' ) ) {
+            $clean = \Normalizer::normalize( $clean, \Normalizer::FORM_D );
+            $clean = preg_replace( '/\p{Mn}+/u', '', $clean );
+        }
+        $map = [ 'á'=>'a','à'=>'a','ã'=>'a','â'=>'a','é'=>'e','ê'=>'e','í'=>'i','ó'=>'o','ô'=>'o','õ'=>'o','ú'=>'u','ü'=>'u','ç'=>'c' ];
+        $clean = strtr( $clean, $map );
+        return $clean;
+    }
+}


### PR DESCRIPTION
Este PR inclui:\n\n- Correção erro de mapeamento (remoção de chamadas inexistentes set_taxonomy)\n- Normalização centralizada de valores (Value_Normalizer)\n- Logs detalhados: apply.start, snapshots, replace_attribute.*, slug_map, resumo final\n- Endpoint REST /variations/update e comando CLI variations-update\n- Simulação via CLI (simulate) para criação de produto de teste\n- Atualização de templates de atributos após mapeamento\n- Backup antes de apply quando solicitado\n\nPróximos passos sugeridos (não implementados):\n- Categorizar motivos de skip em variações\n- Auditoria de variações\n- Otimização de logs redundantes\n\nPor favor revisar.